### PR TITLE
Use default environment for MACOSX_DEPLOYMENT_TARGET

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1052,7 +1052,7 @@ require_gcc() {
 
   export CC="$gcc"
   if [ "$(uname -s)" = "Darwin" ] && [ "$(osx_version)" -ge 1010 ]; then
-    export MACOSX_DEPLOYMENT_TARGET=10.9
+    export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:="10.9"}
   fi
 }
 
@@ -1781,7 +1781,7 @@ if [[ "Darwin" == "$(uname -s)" ]]; then
   MACOS_VERSION="$(sw_vers -productVersion 2>/dev/null || true)"
   MACOS_VERSION_ARRAY=(${MACOS_VERSION//\./ })
   if [ "${#MACOS_VERSION_ARRAY[@]}" -ge 2 ]; then
-    export MACOSX_DEPLOYMENT_TARGET="${MACOS_VERSION_ARRAY[0]}.${MACOS_VERSION_ARRAY[1]}"
+    export MACOSX_DEPLOYMENT_TARGET=${MACOSX_DEPLOYMENT_TARGET:="${MACOS_VERSION_ARRAY[0]}.${MACOS_VERSION_ARRAY[1]}"}
   fi
 fi
 


### PR DESCRIPTION
I have defined MACOSX_DEPLOYMENT_TARGET myself. pyenv should read my
settings as the default value.

I need to build flat 10.6-intel pythons for compatible wheels.
Related article: http://lepture.com/en/2014/python-on-a-hard-wheel