### PR TITLE
fish shell/ pyenv init information / direct user to place new code at end of file

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -50,15 +50,13 @@ if [ -z "$print" ]; then
   esac
 
   { echo "# Load pyenv automatically by adding"
+    echo "# the following to the end of ${profile}:"
+    echo
     case "$shell" in
     fish )
-      echo "# the following to the end of ${profile}:"
-      echo
       echo 'status --is-interactive; and . (pyenv init -|psub)'
       ;;
     * )
-      echo "# the following to ${profile}:"
-      echo
       echo 'eval "$(pyenv init -)"'
       ;;
     esac

--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -50,13 +50,15 @@ if [ -z "$print" ]; then
   esac
 
   { echo "# Load pyenv automatically by adding"
-    echo "# the following to ${profile}:"
-    echo
     case "$shell" in
     fish )
+      echo "# the following to the end of ${profile}:"
+      echo
       echo 'status --is-interactive; and . (pyenv init -|psub)'
       ;;
     * )
+      echo "# the following to ${profile}:"
+      echo
       echo 'eval "$(pyenv init -)"'
       ;;
     esac


### PR DESCRIPTION
Thanks for pyenv - it is great!

I use the fish shell and was having issues getting it to work. I, not thinking, placed the command 

```status --is-interactive; and . (pyenv init -|psub)```

before some of my path jockeying in the config.fish file. After moving the command to the end the config, after my path manipulation logic, pyenv worked perfectly.

This PR changes the informational message for fish shell users by telling them to place the command *at the end of the file*.

Thanks again!