### PR TITLE
fix pypy-2.5.0-src build directory

### DIFF
--- a/plugins/python-build/share/python-build/pypy-2.5.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-c6ad44ecf5d8" "https://bitbucket.org/pypy/pypy/get/release-2.5.0.tar.bz2#8d644a55a3150cf3d18536c784e3410bb3f3438c1505000c4f761863bacedf88" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-pypy-10f1b29a2bd2" "https://bitbucket.org/pypy/pypy/get/release-2.5.0.tar.bz2#8d644a55a3150cf3d18536c784e3410bb3f3438c1505000c4f761863bacedf88" "pypy_builder" verify_py27 ensurepip


### PR DESCRIPTION
When I tried to install pypy-2.5.0-src I got this error:

```
pushd: pypy-pypy-c6ad44ecf5d8: No such file or directory
```

Looks like when 2.5.0 was added in b9ae43a9, they forgot to change the build directory and just copied the one from pypy-2.4.0-src.