### PR TITLE
Fix require_distro

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1140,13 +1140,13 @@ require_java() {
 
 require_distro() {
   for arg; do
-    if [[ "$(cat /etc/issue 2>/dev/null || true)" == "$1"* ]]; then
+    if [[ "$(cat /etc/issue 2>/dev/null || true)" == "$arg"* ]]; then
       return 0
     fi
   done
   { echo
     colorize 1 "WARNING"
-    echo ": This binary distribution is built for $1."
+    echo ": This binary distribution is built for the following distro(s): $@."
     echo "installed binary may not run expectedly on other platforms."
     echo
   } >&2

--- a/plugins/python-build/share/python-build/pypy-2.5.0
+++ b/plugins/python-build/share/python-build/pypy-2.5.0
@@ -19,7 +19,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "linux64" )
-  if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
+  if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
     install_package "pypy-2.5.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
   else
     install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-2.5.1
@@ -24,7 +24,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "linux64" )
-  if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
+  if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
     install_package "pypy-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
   else
     # FIXME: portable distribution not yet available


### PR DESCRIPTION
The `require_distro` function loops over all distro names passed to it, but constantly checks the current distro against the first argument. Thus, some pythons (e.g. pypy in this case) will fail to install the official binaries unless you are using whatever the first listed supported distro is, even though the binary supports a wide range of distros (like 12.04 thru 14.04).

On a related note, `pypy-2.5.x` binary versions for `linux64` did not have the correct list of supported distros.