### PR TITLE
fix url and checksum for pypy-2.5.1-src

### DIFF
--- a/plugins/python-build/share/python-build/pypy-2.5.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-9c4588d731b7" "https://bitbucket.org/pypy/pypy/get/release-2.5.1.tar.bz2#58cefb30a645f7b535e2b63a1d7c21bf12615ad95324bc6c919df90f7b2f37ef" "pypy_builder" verify_py27 ensurepip
+install_package "pypy-2.5.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip


### PR DESCRIPTION
Sorry to blow up your inbox today...

Looks like the tag/branch for 2.5.1 moved after I computed the expected checksum. When I downloaded the release, it was at commit [9c4588d](https://bitbucket.org/pypy/pypy/commits/9c4588d), but is now at [e3d046c](https://bitbucket.org/pypy/pypy/commits/e3d046c). I also see a few commits in the log indicating that the tag for 2.5.1 was moved.

At any rate, I switched the url to the bitbucket downloads page since that is what http://pypy.org/download.html links to. This will ensure that the file we download won't change unless they re-upload it manually.