### PR TITLE
2.7.9 - Stop '/Library/Python/X.X/site-packages' from being added to sys.path

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.7.9/Python-2.7.9/003_system_library_path_in_sys_path.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.9/Python-2.7.9/003_system_library_path_in_sys_path.patch
@@ -1,0 +1,13 @@
+Only in .: 003_system_library_path_in_sys_path.patch
+diff -ur ../Python-2.7.9/Lib/site.py ./Lib/site.py
+--- ../Python-2.7.9/Lib/site.py	2014-06-30 05:05:30.000000000 +0300
++++ ./Lib/site.py	2014-12-12 11:42:33.000000000 +0200
+@@ -300,7 +300,7 @@
+             # locations.
+             from sysconfig import get_config_var
+             framework = get_config_var("PYTHONFRAMEWORK")
+-            if framework:
++            if False and framework:
+                 sitepackages.append(
+                         os.path.join("/Library", framework,
+                             sys.version[:3], "site-packages"))


### PR DESCRIPTION
This is just a copy/paste of https://github.com/yyuu/pyenv/pull/292 to support 2.7.9 to solve the issue in  https://github.com/yyuu/pyenv/issues/282