### PR TITLE
src/configure: fix sed expression

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -39,8 +39,8 @@ sed "
   s,@SHOBJ_CC@,${SHOBJ_CC},
   s,@SHOBJ_CFLAGS@,${SHOBJ_CFLAGS},
   s,@SHOBJ_LD@,${SHOBJ_LD},
-  s,@SHOBJ_LDFLAGS@,${SHOBJ_LDFLAGS//,/\,},
-  s,@SHOBJ_XLDFLAGS@,${SHOBJ_XLDFLAGS//,/\,},
+  s,@SHOBJ_LDFLAGS@,${SHOBJ_LDFLAGS//,/\\,},
+  s,@SHOBJ_XLDFLAGS@,${SHOBJ_XLDFLAGS//,/\\,},
   s,@SHOBJ_LIBS@,${SHOBJ_LIBS},
   s,@SHOBJ_STATUS@,${SHOBJ_STATUS},
 " "$src_dir"/Makefile.in > "$src_dir"/Makefile


### PR DESCRIPTION
This has been fixed for rbenv in
https://github.com/sstephenson/rbenv/commit/050f750.

Ref: https://github.com/sstephenson/rbenv/pull/706