### PR TITLE
pip-rehash: handle versions in commands, like "pip2" and "pip3.4"

### DIFF
--- a/pyenv.d/exec/pip-rehash.bash
+++ b/pyenv.d/exec/pip-rehash.bash
@@ -1,5 +1,13 @@
 PYENV_PIP_REHASH_ROOT="${BASH_SOURCE[0]%/*}/pip-rehash"
-if [ -x "${PYENV_PIP_REHASH_ROOT}/${PYENV_COMMAND##*/}" ]; then
-  PYENV_COMMAND_PATH="${PYENV_PIP_REHASH_ROOT}/${PYENV_COMMAND##*/}"
+PYENV_REHASH_COMMAND="${PYENV_COMMAND##*/}"
+
+# Remove any version information, from e.g. "pip2" or "pip3.4".
+if [[ $PYENV_REHASH_COMMAND =~ ^(pip|easy_install)[23](\.\d)?$ ]]; then
+  PYENV_REHASH_COMMAND="${BASH_REMATCH[1]}"
+fi
+
+if [ -x "${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND}" ]; then
+  PYENV_COMMAND_PATH="${PYENV_PIP_REHASH_ROOT}/${PYENV_REHASH_COMMAND##*/}"
   PYENV_BIN_PATH="${PYENV_PIP_REHASH_ROOT}"
+  export PYENV_REHASH_REAL_COMMAND="${PYENV_COMMAND##*/}"
 fi

--- a/pyenv.d/exec/pip-rehash/easy_install
+++ b/pyenv.d/exec/pip-rehash/easy_install
@@ -11,7 +11,7 @@ _PATH="${_PATH#:}"
 _PATH="${_PATH%:}"
 PATH="${_PATH}"
 
-PYENV_COMMAND_PATH="$(pyenv-which "$(basename "$0")")"
+PYENV_COMMAND_PATH="$(pyenv-which "${PYENV_REHASH_REAL_COMMAND}")"
 PYENV_BIN_PATH="${PYENV_COMMAND_PATH%/*}"
 
 export PATH="${PYENV_BIN_PATH}:${PATH}"

--- a/pyenv.d/exec/pip-rehash/pip
+++ b/pyenv.d/exec/pip-rehash/pip
@@ -11,7 +11,7 @@ _PATH="${_PATH#:}"
 _PATH="${_PATH%:}"
 PATH="${_PATH}"
 
-PYENV_COMMAND_PATH="$(pyenv-which "$(basename "$0")")"
+PYENV_COMMAND_PATH="$(pyenv-which "${PYENV_REHASH_REAL_COMMAND}")"
 PYENV_BIN_PATH="${PYENV_COMMAND_PATH%/*}"
 
 export PATH="${PYENV_BIN_PATH}:${PATH}"


### PR DESCRIPTION
I've came up with the regexp before I've noticed that only pip and easyinstall are affected, so this could get optimized / simplified maybe.

Also the exporting of `PYENV_REHASH_REAL_COMMAND` feels dirty, but is required for the inner communication.

Fixes https://github.com/yyuu/pyenv/issues/367