### PR TITLE
Fix Pip install on python 3.1.x

### DIFF
--- a/plugins/python-build/share/python-build/3.1
+++ b/plugins/python-build/share/python-build/3.1
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1" "http://python.org/ftp/python/3.1/Python-3.1.tgz#99a034cf574ea3c26412b0a0728126d7fd6ea9593d099d807a25d216ed031e6a" ldflags_dirs standard verify_py31 ez_setup
+install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.1
+++ b/plugins/python-build/share/python-build/3.1.1
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.1" "http://python.org/ftp/python/3.1.1/Python-3.1.1.tgz#5d85d7bff11c4db44920af99f64f4227c816f897f6bfa9dd8a2611165ca5f0a1" ldflags_dirs standard verify_py31 ez_setup
+install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.2
+++ b/plugins/python-build/share/python-build/3.1.2
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.2" "http://python.org/ftp/python/3.1.2/Python-3.1.2.tgz#dffbc0561a161a4a576c6059e6990a9859a0be16ba9b5736eabe4abbb2700d1c" ldflags_dirs standard verify_py31 ez_setup
+install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.3
+++ b/plugins/python-build/share/python-build/3.1.3
@@ -1,3 +1,4 @@
 #require_gcc
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.3" "http://python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" ldflags_dirs standard verify_py31 ensurepip
+install_package "Python-3.1.3" "http://python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" ldflags_dirs standard verify_py31 ez_setup
+install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.4
+++ b/plugins/python-build/share/python-build/3.1.4
@@ -1,3 +1,4 @@
 #require_gcc
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.4" "http://python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" ldflags_dirs standard verify_py31 ensurepip
+install_package "Python-3.1.4" "http://python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" ldflags_dirs standard verify_py31 ez_setup
+install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python


### PR DESCRIPTION
see #351

also added missing 3.1.x releases.