### PR TITLE
pyenv-version-file-read: use sed instead of type/head/awk

### DIFF
--- a/libexec/pyenv-version-file-read
+++ b/libexec/pyenv-version-file-read
@@ -9,7 +9,7 @@ if [ -e "$VERSION_FILE" ]; then
   # Read the first non-whitespace word from the specified version file.
   # Be careful not to load it whole in case there's something crazy in it.
   IFS="${IFS}"$'\r'
-  words=( $(cut -b 1-1024 "$VERSION_FILE" | $(type -p gawk awk | head -1) '{ print($1) }') )
+  words=($(cut -b 1-1024 "$VERSION_FILE" | sed 's/^\s*\(\S\+\).*/\1/'))
   versions=("${words[@]}")
 
   if [ -n "$versions" ]; then


### PR DESCRIPTION
I was seeing the following occasionally in scripts:

> …/.pyenv/libexec/pyenv-version-file-read: line 12: type: write error: Broken pipe

This patch hopefully improves/fixes this, and it seems better anyway to
just use sed here.

I've not tested this with OS X's default `sed`.