### PR TITLE
Display version origin with non-installed versions

### DIFF
--- a/libexec/pyenv-version-name
+++ b/libexec/pyenv-version-name
@@ -28,7 +28,7 @@ OLDIFS="$IFS"
     elif version_exists "${version#python-}"; then
       versions=("${versions[@]}" "${version#python-}")
     else
-      echo "pyenv: version \`$version' is not installed" >&2
+      echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
       any_not_installed=1
     fi
   done

--- a/libexec/pyenv-which
+++ b/libexec/pyenv-which
@@ -65,7 +65,7 @@ else
       continue
     fi
     if ! [ -d "${PYENV_ROOT}/versions/${version}" ]; then
-      echo "pyenv: version \`$version' is not installed" >&2
+      echo "pyenv: version \`$version' is not installed (set by $(pyenv-version-origin))" >&2
       any_not_installed=1
     fi
   done

--- a/test/exec.bats
+++ b/test/exec.bats
@@ -17,7 +17,7 @@ create_executable() {
 @test "fails with invalid version" {
   export PYENV_VERSION="3.4"
   run pyenv-exec python -v
-  assert_failure "pyenv: version \`3.4' is not installed"
+  assert_failure "pyenv: version \`3.4' is not installed (set by PYENV_VERSION environment variable)"
 }
 
 @test "completes with names of executables" {

--- a/test/version-name.bats
+++ b/test/version-name.bats
@@ -49,7 +49,7 @@ setup() {
 
 @test "missing version" {
   PYENV_VERSION=1.2 run pyenv-version-name
-  assert_failure "pyenv: version \`1.2' is not installed"
+  assert_failure "pyenv: version \`1.2' is not installed (set by PYENV_VERSION environment variable)"
 }
 
 @test "one missing version (second missing)" {
@@ -57,7 +57,7 @@ setup() {
   PYENV_VERSION="3.4.2:1.2" run pyenv-version-name
   assert_failure
   assert_output <<OUT
-pyenv: version \`1.2' is not installed
+pyenv: version \`1.2' is not installed (set by PYENV_VERSION environment variable)
 3.4.2
 OUT
 }
@@ -67,7 +67,7 @@ OUT
   PYENV_VERSION="1.2:3.4.2" run pyenv-version-name
   assert_failure
   assert_output <<OUT
-pyenv: version \`1.2' is not installed
+pyenv: version \`1.2' is not installed (set by PYENV_VERSION environment variable)
 3.4.2
 OUT
 }

--- a/test/version.bats
+++ b/test/version.bats
@@ -42,7 +42,7 @@ setup() {
   PYENV_VERSION=3.3.3:1.2 run pyenv-version
   assert_failure
   assert_output <<OUT
-pyenv: version \`1.2' is not installed
+pyenv: version \`1.2' is not installed (set by PYENV_VERSION environment variable)
 3.3.3 (set by PYENV_VERSION environment variable)
 OUT
 }
@@ -52,8 +52,8 @@ OUT
   PYENV_VERSION=3.4.2:3.3.3:1.2 run pyenv-version
   assert_failure
   assert_output <<OUT
-pyenv: version \`3.4.2' is not installed
-pyenv: version \`1.2' is not installed
+pyenv: version \`3.4.2' is not installed (set by PYENV_VERSION environment variable)
+pyenv: version \`1.2' is not installed (set by PYENV_VERSION environment variable)
 3.3.3 (set by PYENV_VERSION environment variable)
 OUT
 }

--- a/test/which.bats
+++ b/test/which.bats
@@ -62,15 +62,15 @@ create_executable() {
 @test "version not installed" {
   create_executable "3.4" "py.test"
   PYENV_VERSION=3.3 run pyenv-which py.test
-  assert_failure "pyenv: version \`3.3' is not installed"
+  assert_failure "pyenv: version \`3.3' is not installed (set by PYENV_VERSION environment variable)"
 }
 
 @test "versions not installed" {
   create_executable "3.4" "py.test"
   PYENV_VERSION=2.7:3.3 run pyenv-which py.test
   assert_failure <<OUT
-pyenv: version \`2.7' is not installed
-pyenv: version \`3.3' is not installed
+pyenv: version \`2.7' is not installed (set by PYENV_VERSION environment variable)
+pyenv: version \`3.3' is not installed (set by PYENV_VERSION environment variable)
 OUT
 }
 


### PR DESCRIPTION
This is useful as an indicator where it is coming from.

Submitted for rbenv at: https://github.com/sstephenson/rbenv/pull/756,
but pyenv has more tests in this regard.