### PR TITLE
Add `3.6-dev`

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1517,6 +1517,11 @@ build_package_verify_py35() {
   build_package_verify_py34 "$1" "${2:-3.5}"
 }
 
+# Post-install check for Python 3.6.x
+build_package_verify_py36() {
+  build_package_verify_py35 "$1" "${2:-3.6}"
+}
+
 build_package_ez_setup() {
   local ez_setup="${BUILD_PATH}/ez_setup.py"
   rm -f "${ez_setup}"

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,0 +1,3 @@
+#require_gcc
+install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_hg "Python-3.6-dev" "https://hg.python.org/cpython" "default" standard verify_py36 ensurepip


### PR DESCRIPTION
With the switch to hg.python.org, we need to build `3.6-dev`.

This has been tested [here](https://travis-ci.org/travis-ci/cpython-builder/builds/71512737); Checks out the branch at https://travis-ci.org/travis-ci/cpython-builder/builds/71512737#L121, then proceeds to use the script https://travis-ci.org/travis-ci/cpython-builder/builds/71512737#L140 to build it.