### PR TITLE
Add scripts for miniconda*-3.16.0.

### DIFF
--- a/plugins/python-build/share/python-build/miniconda-3.16.0
+++ b/plugins/python-build/share/python-build/miniconda-3.16.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda-3.16.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86.sh#57e9659848e6322cb18c1c4a5c844a4f7dc5e784dbd8977245769ff9db28dade" "miniconda" verify_py27 
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda-3.16.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh#b1facded0d33850e3a467d6e4589830be477bd4f819407b99b033a4d22601e4d" "miniconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda-3.16.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.16.0-MacOSX-x86_64.sh#e93517696d4ede4f8ff21ea42272f24508023b83f1e2e2c989d1b32ab19347a9" "miniconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda3-3.16.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.16.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Miniconda3-3.16.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86.sh#faedb7a75584d48d563f0f9b449cb00bf8d05ddb3e1ede1936bf522f03f0e1e2" "miniconda" verify_py34
+  ;;
+"Linux-x86_64" )
+  install_script "Miniconda3-3.16.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh#3becbcdd36761711850cffa11064b87cfe067dbeb4a5eda544dc341af482de87" "miniconda" verify_py34
+  ;;
+"MacOSX-x86_64" )
+  install_script "Miniconda3-3.16.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.16.0-MacOSX-x86_64.sh#36fe954548a6900249270f9632b76252e247313cc9d551c096d7e1f526a88631" "miniconda" verify_py34
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Miniconda is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac


### PR DESCRIPTION
Downloaded Linux-x86/Linux-x86_64//MacOSX-x86_64 installers and generated sha256sum locally.
```
sha256sum Miniconda*-3.16.0-*.sh
b1facded0d33850e3a467d6e4589830be477bd4f819407b99b033a4d22601e4d  Miniconda-3.16.0-Linux-x86_64.sh
57e9659848e6322cb18c1c4a5c844a4f7dc5e784dbd8977245769ff9db28dade  Miniconda-3.16.0-Linux-x86.sh
e93517696d4ede4f8ff21ea42272f24508023b83f1e2e2c989d1b32ab19347a9  Miniconda-3.16.0-MacOSX-x86_64.sh
3becbcdd36761711850cffa11064b87cfe067dbeb4a5eda544dc341af482de87  Miniconda3-3.16.0-Linux-x86_64.sh
faedb7a75584d48d563f0f9b449cb00bf8d05ddb3e1ede1936bf522f03f0e1e2  Miniconda3-3.16.0-Linux-x86.sh
36fe954548a6900249270f9632b76252e247313cc9d551c096d7e1f526a88631  Miniconda3-3.16.0-MacOSX-x86_64.sh
```