### PR TITLE
List Anaconda-style virtual environments as a version in pyenv

### DIFF
--- a/libexec/pyenv-versions
+++ b/libexec/pyenv-versions
@@ -53,6 +53,12 @@ shopt -s nullglob
 for path in "${PYENV_ROOT}/versions/"*; do
   if [ -d "$path" ]; then
     print_version "${path##*/}"
+    # virtual environments created by anaconda/miniconda
+    for env_path in "${path}/envs/"*; do
+      if [ -d "${env_path}" ]; then
+        print_version "${env_path#${PYENV_ROOT}/versions/}"
+      fi
+    done
   fi
 done
 shopt -u nullglob


### PR DESCRIPTION
List virtualenv created in `envs` directory as a version, to improve the interoperability between Anaconda/Miniconda.

```sh
% pyenv versions
  system
* 3.4.3 (set by /home/yyuu/.pyenv/version)
  3.4.3/envs/bar
  3.4.3/envs/foo
  miniconda3-3.16.0
  miniconda3-3.16.0/envs/foo
```