### PR TITLE
Adding SSL patch to build 2.7.3 on Debian

### DIFF
--- a/plugins/python-build/share/python-build/patches/2.7.3/Python-2.7.3/004_ssl.patch
+++ b/plugins/python-build/share/python-build/patches/2.7.3/Python-2.7.3/004_ssl.patch
@@ -1,0 +1,13 @@
+--- Modules/_ssl.c.orig	2015-12-06 09:38:40.581734108 -0500
++++ Modules/_ssl.c	2015-12-06 09:40:29.953991951 -0500
+@@ -302,8 +302,10 @@
+     PySSL_BEGIN_ALLOW_THREADS
+     if (proto_version == PY_SSL_VERSION_TLS1)
+         self->ctx = SSL_CTX_new(TLSv1_method()); /* Set up context */
++#ifndef OPENSSL_NO_SSL3
+     else if (proto_version == PY_SSL_VERSION_SSL3)
+         self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
++#endif
+ #ifndef OPENSSL_NO_SSL2
+     else if (proto_version == PY_SSL_VERSION_SSL2)
+         self->ctx = SSL_CTX_new(SSLv2_method()); /* Set up context */


### PR DESCRIPTION
This allows me to build 2.7.3 on debian now. Without this patch, I get the following error:

```
/tmp/python-build.20151206091414.18928/Python-2.7.3/Modules/_ssl.c: In function ‘newPySSLObject’:
/tmp/python-build.20151206091414.18928/Python-2.7.3/Modules/_ssl.c:306:33: warning: implicit declaration of function ‘SSLv3_method’ [-Wimplicit-function-declaration]
         self->ctx = SSL_CTX_new(SSLv3_method()); /* Set up context */
                                 ^
/tmp/python-build.20151206091414.18928/Python-2.7.3/Modules/_ssl.c:306:33: warning: passing argument 1 of ‘SSL_CTX_new’ makes pointer from integer without a cast [-Wint-conversion]
In file included from /tmp/python-build.20151206091414.18928/Python-2.7.3/Modules/_ssl.c:88:0:
/usr/include/openssl/ssl.h:2131:10: note: expected ‘const SSL_METHOD * {aka const struct ssl_method_st *}’ but argument is of type ‘int’
 SSL_CTX *SSL_CTX_new(const SSL_METHOD *meth);
          ^
gcc -pthread -shared -L/home/catlee/.pyenv/versions/2.7.3/lib -L/home/catlee/.pyenv/versions/2.7.3/lib -I. -IInclude -I./Include -I/home/catlee/.pyenv/versions/2.7.3/include build/temp.linux-x86_64-2.7/tmp/python-build.20151206091414.18928/Python-2.7.3/Modules/_ssl.o -L/home/catlee/.pyenv/versions/2.7.3/lib -L/usr/lib/x86_64-linux-gnu -L/usr/local/lib -lssl -lcrypto -o build/lib.linux-x86_64-2.7/_ssl.so
*** WARNING: renaming "_ssl" since importing it failed: build/lib.linux-x86_64-2.7/_ssl.so: undefined symbol: SSLv3_method
```