### PR TITLE
Fix error about symbolic link

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -40,7 +40,7 @@ abs_dirname() {
   local path="$1"
 
   while [ -n "$path" ]; do
-    cd "${path%/*}"
+    [ -d "${path%/*}" ] && cd "${path%/*}"
     local name="${path##*/}"
     path="$(resolve_link "$name" || true)"
   done


### PR DESCRIPTION
Fix the error below

```

$ mkdir testdir; echo "print 'hello'" > testdir/test.py; ln -s test.py testdir/test; python testdir/test
/Users/meng/.pyenv/libexec/pyenv: line 43: cd: test.py: Not a directory
hello

```