### PR TITLE
Prevent duplicate PATH entries

### DIFF
--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -86,7 +86,7 @@ bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${PYENV_ROOT}/plugins/"*/bin; do
   PATH="${plugin_bin}:${PATH}"
 done
-export PATH="${bin_path}:${PATH}"
+[[ ":${PATH}:" == *":${bin_path}:"* ]] || export PATH="${bin_path}:${PATH}"
 
 PYENV_HOOK_PATH="${PYENV_HOOK_PATH}:${PYENV_ROOT}/pyenv.d"
 if [ "${bin_path%/*}" != "$PYENV_ROOT" ]; then

--- a/libexec/pyenv
+++ b/libexec/pyenv
@@ -84,7 +84,7 @@ shopt -s nullglob
 
 bin_path="$(abs_dirname "$0")"
 for plugin_bin in "${PYENV_ROOT}/plugins/"*/bin; do
-  PATH="${plugin_bin}:${PATH}"
+  [[ ":${PATH}:" == *":${plugin_bin}:"* ]] || export PATH="${plugin_bin}:${PATH}"
 done
 [[ ":${PATH}:" == *":${bin_path}:"* ]] || export PATH="${bin_path}:${PATH}"
 


### PR DESCRIPTION
Prevents PATH population in the event the pyenv is initialized twice (e.g. once in shell create, a second time in tmux/screen session).