### PR TITLE
Update build scripts for Continuum products

### DIFF
--- a/plugins/python-build/share/python-build/anaconda-1.4.0
+++ b/plugins/python-build/share/python-build/anaconda-1.4.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.4.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.4.0-Linux-x86.sh#065284c5de369c9b89dcae79e7169ce9b734dc3bbe6c409a67a5ec6480cc0f40" "anaconda" verify_py27
+  install_script "Anaconda-1.4.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.4.0-Linux-x86.sh#065284c5de369c9b89dcae79e7169ce9b734dc3bbe6c409a67a5ec6480cc0f40" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.4.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.4.0-Linux-x86_64.sh#85ae8a0a6e3a41cf7845be3def36ed40582d3dc6e6a50e99063eaf6f1abee24e" "anaconda" verify_py27
+  install_script "Anaconda-1.4.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.4.0-Linux-x86_64.sh#85ae8a0a6e3a41cf7845be3def36ed40582d3dc6e6a50e99063eaf6f1abee24e" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.4.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.4.0-MacOSX-x86_64.sh#e5d5dae6e93bb7df528abc19f5ed3a69cc4bc867836bdc56886c5a3768fccde7" "anaconda" verify_py27
+  install_script "Anaconda-1.4.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.4.0-MacOSX-x86_64.sh#e5d5dae6e93bb7df528abc19f5ed3a69cc4bc867836bdc56886c5a3768fccde7" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.5.0
+++ b/plugins/python-build/share/python-build/anaconda-1.5.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.5.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.5.0-Linux-x86.sh#ca7e356dc1b8c8ef27dfb74b32c77563df704c6ddb39e69cac65ec416ebfe8e5" "anaconda" verify_py27
+  install_script "Anaconda-1.5.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.5.0-Linux-x86.sh#ca7e356dc1b8c8ef27dfb74b32c77563df704c6ddb39e69cac65ec416ebfe8e5" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.5.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.5.0-Linux-x86_64.sh#f4cdc194f076e1b438c8a34e7e5f53e70c2200b411b2d0af719e23fe35c6411e" "anaconda" verify_py27
+  install_script "Anaconda-1.5.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.5.0-Linux-x86_64.sh#f4cdc194f076e1b438c8a34e7e5f53e70c2200b411b2d0af719e23fe35c6411e" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.5.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.5.0-MacOSX-x86_64.sh#c69609f0f48f33ca5a12d425a9e4d0fc91b2c09d0345a590e1d77726446727aa" "anaconda" verify_py27
+  install_script "Anaconda-1.5.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.5.0-MacOSX-x86_64.sh#c69609f0f48f33ca5a12d425a9e4d0fc91b2c09d0345a590e1d77726446727aa" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.5.1
+++ b/plugins/python-build/share/python-build/anaconda-1.5.1
@@ -1,6 +1,6 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.5.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.5.1-MacOSX-x86_64.sh#6d3c86a2fdbaeeec2a6c251d5c9034a32b7c68a0437f2fac0b8f25125fe6866f" "anaconda" verify_py27
+  install_script "Anaconda-1.5.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.5.1-MacOSX-x86_64.sh#6d3c86a2fdbaeeec2a6c251d5c9034a32b7c68a0437f2fac0b8f25125fe6866f" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.6.0
+++ b/plugins/python-build/share/python-build/anaconda-1.6.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.6.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.6.0-Linux-x86.sh#d6aeedfcb39d648fdfb5bd72c4d0b3063a9d4f4866baf5052aa0645bf5d2c07a" "anaconda" verify_py27
+  install_script "Anaconda-1.6.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.6.0-Linux-x86.sh#d6aeedfcb39d648fdfb5bd72c4d0b3063a9d4f4866baf5052aa0645bf5d2c07a" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.6.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.6.0-Linux-x86_64.sh#20f5b70193af4b0b8f10aa0e66aabca552846ec8f4958757ff3f4b79ef7b3160" "anaconda" verify_py27
+  install_script "Anaconda-1.6.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.6.0-Linux-x86_64.sh#20f5b70193af4b0b8f10aa0e66aabca552846ec8f4958757ff3f4b79ef7b3160" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.6.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.6.0-MacOSX-x86_64.sh#e03317888c36c07451a349577b426f435a75075d1ee71e204eb9d5dd23936f5e" "anaconda" verify_py27
+  install_script "Anaconda-1.6.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.6.0-MacOSX-x86_64.sh#e03317888c36c07451a349577b426f435a75075d1ee71e204eb9d5dd23936f5e" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.6.1
+++ b/plugins/python-build/share/python-build/anaconda-1.6.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.6.1-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.6.1-Linux-x86.sh#745b9452fd18720deefb465a6687c0d66df8f11edceadcee758082dea1b8e812" "anaconda" verify_py27
+  install_script "Anaconda-1.6.1-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.6.1-Linux-x86.sh#745b9452fd18720deefb465a6687c0d66df8f11edceadcee758082dea1b8e812" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.6.1-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.6.1-Linux-x86_64.sh#81d1819ba08069343f228b9c819cdba0e4d15f2142c0c033657599808c3960fb" "anaconda" verify_py27
+  install_script "Anaconda-1.6.1-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.6.1-Linux-x86_64.sh#81d1819ba08069343f228b9c819cdba0e4d15f2142c0c033657599808c3960fb" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.6.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.6.1-MacOSX-x86_64.sh#bbc15de34208ce8af5aceedeea1334636fe94c578b9890896729f1a61ace5e4f" "anaconda" verify_py27
+  install_script "Anaconda-1.6.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.6.1-MacOSX-x86_64.sh#bbc15de34208ce8af5aceedeea1334636fe94c578b9890896729f1a61ace5e4f" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.7.0
+++ b/plugins/python-build/share/python-build/anaconda-1.7.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.7.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.7.0-Linux-x86.sh#af372a27a1887e11061485e2a854c535775fd519713e028c38901f90c869cd83" "anaconda" verify_py27
+  install_script "Anaconda-1.7.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.7.0-Linux-x86.sh#af372a27a1887e11061485e2a854c535775fd519713e028c38901f90c869cd83" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.7.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.7.0-Linux-x86_64.sh#6115cfae55a0746b4ae4128be839c99db39d02124160d9c531ca086c4d606582" "anaconda" verify_py27
+  install_script "Anaconda-1.7.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.7.0-Linux-x86_64.sh#6115cfae55a0746b4ae4128be839c99db39d02124160d9c531ca086c4d606582" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.7.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.7.0-MacOSX-x86_64.sh#046b592245bc2c11e733acb9700dc50947f2eff0f30fec4a4a5bf79368dfa14b" "anaconda" verify_py27
+  install_script "Anaconda-1.7.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.7.0-MacOSX-x86_64.sh#046b592245bc2c11e733acb9700dc50947f2eff0f30fec4a4a5bf79368dfa14b" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.8.0
+++ b/plugins/python-build/share/python-build/anaconda-1.8.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.8.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.8.0-Linux-x86.sh#2c08a5cd6ccaa9dc84063b0ee9b007aa82e35a75c340fb272b394896de853608" "anaconda" verify_py27
+  install_script "Anaconda-1.8.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.8.0-Linux-x86.sh#2c08a5cd6ccaa9dc84063b0ee9b007aa82e35a75c340fb272b394896de853608" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.8.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.8.0-Linux-x86_64.sh#69f42966d918f4197040e4dd126d2e3cc3c267bb49869dbf2d6ef277ed5de8b7" "anaconda" verify_py27
+  install_script "Anaconda-1.8.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.8.0-Linux-x86_64.sh#69f42966d918f4197040e4dd126d2e3cc3c267bb49869dbf2d6ef277ed5de8b7" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.8.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.8.0-MacOSX-x86_64.sh#5844ca595b5930399a1213db64ab53e9b7e2fc1c26d8f11769c161fe4f5661e6" "anaconda" verify_py27
+  install_script "Anaconda-1.8.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.8.0-MacOSX-x86_64.sh#5844ca595b5930399a1213db64ab53e9b7e2fc1c26d8f11769c161fe4f5661e6" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.9.0
+++ b/plugins/python-build/share/python-build/anaconda-1.9.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.9.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.9.0-Linux-x86.sh#16471e90b3deb7be1b3d449d8883983d81f035dfaa1a3391497de20577de6f66" "anaconda" verify_py27
+  install_script "Anaconda-1.9.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.9.0-Linux-x86.sh#16471e90b3deb7be1b3d449d8883983d81f035dfaa1a3391497de20577de6f66" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.9.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.9.0-Linux-x86_64.sh#855f1265e4c0b40d50f5a3a0fe7bae05b1cccb0a5301b378a19e0a8f7262913a" "anaconda" verify_py27
+  install_script "Anaconda-1.9.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.9.0-Linux-x86_64.sh#855f1265e4c0b40d50f5a3a0fe7bae05b1cccb0a5301b378a19e0a8f7262913a" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.9.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.9.0-MacOSX-x86_64.sh#722fe4d4406e88c5023e7ee21dc1401bb2a540d6c031d303f0330a95e60131fd" "anaconda" verify_py27
+  install_script "Anaconda-1.9.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.9.0-MacOSX-x86_64.sh#722fe4d4406e88c5023e7ee21dc1401bb2a540d6c031d303f0330a95e60131fd" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.9.1
+++ b/plugins/python-build/share/python-build/anaconda-1.9.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.9.1-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.9.1-Linux-x86.sh#9aa39c05f723fee18c54a9cc1729986193216affedbae125ca5faa067403030a" "anaconda" verify_py27
+  install_script "Anaconda-1.9.1-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.9.1-Linux-x86.sh#9aa39c05f723fee18c54a9cc1729986193216affedbae125ca5faa067403030a" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.9.1-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.9.1-Linux-x86_64.sh#f6455e06a72b8cc11c8a96fb88a85518a2f7b2a1d6f1065f777d7ab4386f022d" "anaconda" verify_py27
+  install_script "Anaconda-1.9.1-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.9.1-Linux-x86_64.sh#f6455e06a72b8cc11c8a96fb88a85518a2f7b2a1d6f1065f777d7ab4386f022d" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.9.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.9.1-MacOSX-x86_64.sh#7e4358adbaae2db9e17d1e0e4263b9a0174394c8f115c89d285c3f0f9206f75b" "anaconda" verify_py27
+  install_script "Anaconda-1.9.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.9.1-MacOSX-x86_64.sh#7e4358adbaae2db9e17d1e0e4263b9a0174394c8f115c89d285c3f0f9206f75b" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-1.9.2
+++ b/plugins/python-build/share/python-build/anaconda-1.9.2
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-1.9.2-Linux-x86" "http://repo.continuum.io/archive/Anaconda-1.9.2-Linux-x86.sh#1f7c850d0b98c011a717b3b757d82077accf0704dd7627f6962267bfb4476aad" "anaconda" verify_py27
+  install_script "Anaconda-1.9.2-Linux-x86" "https://repo.continuum.io/archive/Anaconda-1.9.2-Linux-x86.sh#1f7c850d0b98c011a717b3b757d82077accf0704dd7627f6962267bfb4476aad" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-1.9.2-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-1.9.2-Linux-x86_64.sh#7181d399833a2549a9584255bb477487f2fde1fda4c7f7215d6034ea2fcfa21e" "anaconda" verify_py27
+  install_script "Anaconda-1.9.2-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-1.9.2-Linux-x86_64.sh#7181d399833a2549a9584255bb477487f2fde1fda4c7f7215d6034ea2fcfa21e" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-1.9.2-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-1.9.2-MacOSX-x86_64.sh#be4611ca671f80b984fa330d4ecf82244c388abbdb5c7679a4e6e806b4dca52f" "anaconda" verify_py27
+  install_script "Anaconda-1.9.2-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-1.9.2-MacOSX-x86_64.sh#be4611ca671f80b984fa330d4ecf82244c388abbdb5c7679a4e6e806b4dca52f" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-2.0.0
+++ b/plugins/python-build/share/python-build/anaconda-2.0.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-2.0.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-2.0.0-Linux-x86.sh#efb9d3987134d484d88a9d915437b1bd568d065b4fefbd538e0281694bd90888" "anaconda" verify_py27
+  install_script "Anaconda-2.0.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-2.0.0-Linux-x86.sh#efb9d3987134d484d88a9d915437b1bd568d065b4fefbd538e0281694bd90888" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-2.0.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-2.0.0-Linux-x86_64.sh#3aa27ddf4a0ba5046ba52b97da99e20eb0614273d905bd73e016852451908917" "anaconda" verify_py27
+  install_script "Anaconda-2.0.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-2.0.0-Linux-x86_64.sh#3aa27ddf4a0ba5046ba52b97da99e20eb0614273d905bd73e016852451908917" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-2.0.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-2.0.0-MacOSX-x86_64.sh#ad6271ad21403166bf54d0734ba8c7f7eb65bb78a70d67c58c15b6874cddc81e" "anaconda" verify_py27
+  install_script "Anaconda-2.0.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-2.0.0-MacOSX-x86_64.sh#ad6271ad21403166bf54d0734ba8c7f7eb65bb78a70d67c58c15b6874cddc81e" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-2.0.1
+++ b/plugins/python-build/share/python-build/anaconda-2.0.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-2.0.1-Linux-x86" "http://repo.continuum.io/archive/Anaconda-2.0.1-Linux-x86.sh#e8ffc63f31673b5ce41a95796a1f729ddcf4c7db19d6dbe29bedaeaaf8478505" "anaconda" verify_py27
+  install_script "Anaconda-2.0.1-Linux-x86" "https://repo.continuum.io/archive/Anaconda-2.0.1-Linux-x86.sh#e8ffc63f31673b5ce41a95796a1f729ddcf4c7db19d6dbe29bedaeaaf8478505" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-2.0.1-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-2.0.1-Linux-x86_64.sh#074204fa26872b4a946123071d15b8390c0e5441352c6b65b2abd32511bff240" "anaconda" verify_py27
+  install_script "Anaconda-2.0.1-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-2.0.1-Linux-x86_64.sh#074204fa26872b4a946123071d15b8390c0e5441352c6b65b2abd32511bff240" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-2.0.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-2.0.1-MacOSX-x86_64.sh#4ecda163c6f46e70cc6a1fe62dece4c6ecd6474845129cc95a1d4e18c42f8015" "anaconda" verify_py27
+  install_script "Anaconda-2.0.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-2.0.1-MacOSX-x86_64.sh#4ecda163c6f46e70cc6a1fe62dece4c6ecd6474845129cc95a1d4e18c42f8015" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-2.1.0
+++ b/plugins/python-build/share/python-build/anaconda-2.1.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-2.1.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-2.1.0-Linux-x86.sh#fd70c08719e6b5caae45b7c8402c6975a8cbc0e3e2a9c4c977554d1784f28b72" "anaconda" verify_py27
+  install_script "Anaconda-2.1.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-2.1.0-Linux-x86.sh#fd70c08719e6b5caae45b7c8402c6975a8cbc0e3e2a9c4c977554d1784f28b72" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-2.1.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-2.1.0-Linux-x86_64.sh#191fbf290747614929d0bdd576e330c944b22a67585d1c185e0d2b3a3e65e1c0" "anaconda" verify_py27
+  install_script "Anaconda-2.1.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-2.1.0-Linux-x86_64.sh#191fbf290747614929d0bdd576e330c944b22a67585d1c185e0d2b3a3e65e1c0" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-2.1.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-2.1.0-MacOSX-x86_64.sh#128fd4f53e0895e0d23f33e924ae32e01171c2914b044d2b157a9497108109cf" "anaconda" verify_py27
+  install_script "Anaconda-2.1.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-2.1.0-MacOSX-x86_64.sh#128fd4f53e0895e0d23f33e924ae32e01171c2914b044d2b157a9497108109cf" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-2.2.0
+++ b/plugins/python-build/share/python-build/anaconda-2.2.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-2.2.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86.sh#6437d5b08a19c3501f2f5dc3ae1ae16f91adf6bed0f067ef0806a9911b1bef15" "anaconda" verify_py27
+  install_script "Anaconda-2.2.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86.sh#6437d5b08a19c3501f2f5dc3ae1ae16f91adf6bed0f067ef0806a9911b1bef15" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-2.2.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86_64.sh#ca2582cb2188073b0f348ad42207211a2b85c10b244265b5b27bab04481b88a2" "anaconda" verify_py27
+  install_script "Anaconda-2.2.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-2.2.0-Linux-x86_64.sh#ca2582cb2188073b0f348ad42207211a2b85c10b244265b5b27bab04481b88a2" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-2.2.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-2.2.0-MacOSX-x86_64.sh#20570e2f3911e38a78d8f888f3ff445d6c0cf97a2fca40d6956b48d12aaef339" "anaconda" verify_py27
+  install_script "Anaconda-2.2.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-2.2.0-MacOSX-x86_64.sh#20570e2f3911e38a78d8f888f3ff445d6c0cf97a2fca40d6956b48d12aaef339" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda-2.3.0
+++ b/plugins/python-build/share/python-build/anaconda-2.3.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda-2.3.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda-2.3.0-Linux-x86.sh#73fdbbb3e38207ed18e5059f71676d18d48fdccbc455a1272eb45a60376cd818" "anaconda" verify_py27
+  install_script "Anaconda-2.3.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda-2.3.0-Linux-x86.sh#73fdbbb3e38207ed18e5059f71676d18d48fdccbc455a1272eb45a60376cd818" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda-2.3.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda-2.3.0-Linux-x86_64.sh#7c02499e9511c127d225992cfe1cd815e88fd46cd8a5b3cdf764f3fb4d8d4576" "anaconda" verify_py27
+  install_script "Anaconda-2.3.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda-2.3.0-Linux-x86_64.sh#7c02499e9511c127d225992cfe1cd815e88fd46cd8a5b3cdf764f3fb4d8d4576" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda-2.3.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda-2.3.0-MacOSX-x86_64.sh#c4bb59a57bf44dde80612041bbbcfd2e5cab8534842209ef456da7a46f919c33" "anaconda" verify_py27
+  install_script "Anaconda-2.3.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda-2.3.0-MacOSX-x86_64.sh#c4bb59a57bf44dde80612041bbbcfd2e5cab8534842209ef456da7a46f919c33" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda2-2.4.0
+++ b/plugins/python-build/share/python-build/anaconda2-2.4.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda2-2.4.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda2-2.4.0-Linux-x86.sh#478a8fdde3a6e4040a68c57d7bdd6fab1a4f7f6e813948d46dad54867014c124" "anaconda" verify_py27
+  install_script "Anaconda2-2.4.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-2.4.0-Linux-x86.sh#478a8fdde3a6e4040a68c57d7bdd6fab1a4f7f6e813948d46dad54867014c124" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda2-2.4.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda2-2.4.0-Linux-x86_64.sh#49d19834da06b1b82b6fa85bc647d2e78fa5957d0cbae3ccd6c695a541befa6b" "anaconda" verify_py27
+  install_script "Anaconda2-2.4.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-2.4.0-Linux-x86_64.sh#49d19834da06b1b82b6fa85bc647d2e78fa5957d0cbae3ccd6c695a541befa6b" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda2-2.4.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda2-2.4.0-MacOSX-x86_64.sh#53c9123c9d508555100805fdb44d9845511c937e7a34f237beb19168d655e070" "anaconda" verify_py27
+  install_script "Anaconda2-2.4.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-2.4.0-MacOSX-x86_64.sh#53c9123c9d508555100805fdb44d9845511c937e7a34f237beb19168d655e070" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda2-2.4.1
+++ b/plugins/python-build/share/python-build/anaconda2-2.4.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda2-2.4.1-Linux-x86" "http://repo.continuum.io/archive/Anaconda2-2.4.1-Linux-x86.sh#2388cc714567afe7697bf43b4063ff0ea2150a71b9beb17f75bc7e4879d9bf28" "anaconda" verify_py27
+  install_script "Anaconda2-2.4.1-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-2.4.1-Linux-x86.sh#2388cc714567afe7697bf43b4063ff0ea2150a71b9beb17f75bc7e4879d9bf28" "anaconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda2-2.4.1-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda2-2.4.1-Linux-x86_64.sh#2de682c96edf8cca2852071a84ff860025fbe8c502218e1995acd5ab47e8c9ac" "anaconda" verify_py27
+  install_script "Anaconda2-2.4.1-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-2.4.1-Linux-x86_64.sh#2de682c96edf8cca2852071a84ff860025fbe8c502218e1995acd5ab47e8c9ac" "anaconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda2-2.4.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda2-2.4.1-MacOSX-x86_64.sh#f4bd45a21e0dff106e36d11cfd532f2b5050d3b792cc0627ab231089341d2040" "anaconda" verify_py27
+  install_script "Anaconda2-2.4.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-2.4.1-MacOSX-x86_64.sh#f4bd45a21e0dff106e36d11cfd532f2b5050d3b792cc0627ab231089341d2040" "anaconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda2-2.5.0
+++ b/plugins/python-build/share/python-build/anaconda2-2.5.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda2-2.5.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda2-2.5.0-Linux-x86.sh#4911047df51c46661f551d6022aee21a7e5d31df051d3433b8ff3ea3c2e771bb" "anaconda" verify_py27
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda2-2.5.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda2-2.5.0-Linux-x86_64.sh#e10abf459cde4a838bd6fc5ca03023c3401b81ad470627acde5a298d56715321" "anaconda" verify_py27
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda2-2.5.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda2-2.5.0-MacOSX-x86_64.sh#e7aa3b41210ee7ccf3c12e5b5ea43190d1811b58eaeca8584ccffa468ac8a346" "anaconda" verify_py27
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda2 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/anaconda3-2.0.0
+++ b/plugins/python-build/share/python-build/anaconda3-2.0.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.0.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.0.0-Linux-x86.sh#439761159d5604e182951650a478dd53caff52e9dccf17c20ae66689b7b289dd" "anaconda" verify_py34
+  install_script "Anaconda3-2.0.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.0.0-Linux-x86.sh#439761159d5604e182951650a478dd53caff52e9dccf17c20ae66689b7b289dd" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.0.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.0.0-Linux-x86_64.sh#57ce4f97e300cf94c5724f72d992e9eecef708fdaa13bc672ae9779773056540" "anaconda" verify_py34
+  install_script "Anaconda3-2.0.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.0.0-Linux-x86_64.sh#57ce4f97e300cf94c5724f72d992e9eecef708fdaa13bc672ae9779773056540" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.0.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.0.0-MacOSX-x86_64.sh#776a1cf8a8e898b41bb6558c093632cc922698dc48486fee35d1e8eae3f604fa" "anaconda" verify_py34
+  install_script "Anaconda3-2.0.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.0.0-MacOSX-x86_64.sh#776a1cf8a8e898b41bb6558c093632cc922698dc48486fee35d1e8eae3f604fa" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.0.1
+++ b/plugins/python-build/share/python-build/anaconda3-2.0.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.0.1-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.0.1-Linux-x86.sh#21293fabbd3d5cfbb1afe0c9a8b39e0bc4d283cd7dbe3c84a60b335481a41ef3" "anaconda" verify_py34
+  install_script "Anaconda3-2.0.1-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.0.1-Linux-x86.sh#21293fabbd3d5cfbb1afe0c9a8b39e0bc4d283cd7dbe3c84a60b335481a41ef3" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.0.1-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.0.1-Linux-x86_64.sh#3c3b834793e461f3316ad1d9a9178c67859a9d74aaf7bcade076f04134dd1e26" "anaconda" verify_py34
+  install_script "Anaconda3-2.0.1-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.0.1-Linux-x86_64.sh#3c3b834793e461f3316ad1d9a9178c67859a9d74aaf7bcade076f04134dd1e26" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.0.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.0.1-MacOSX-x86_64.sh#7a08509d4e45efcc7055a6d06d8406a773716500bd869a4e85312ff131155bd6" "anaconda" verify_py34
+  install_script "Anaconda3-2.0.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.0.1-MacOSX-x86_64.sh#7a08509d4e45efcc7055a6d06d8406a773716500bd869a4e85312ff131155bd6" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.1.0
+++ b/plugins/python-build/share/python-build/anaconda3-2.1.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.1.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.1.0-Linux-x86.sh#657cb599004c21e37ce693515ea33922e0084fd7c159ef1b96b57c86eed8385f" "anaconda" verify_py34
+  install_script "Anaconda3-2.1.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.1.0-Linux-x86.sh#657cb599004c21e37ce693515ea33922e0084fd7c159ef1b96b57c86eed8385f" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.1.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.1.0-Linux-x86_64.sh#af3225ccbe8df0ffb918939e009aa57740e35058ebf9dfcf5fec794a77556c3c" "anaconda" verify_py34
+  install_script "Anaconda3-2.1.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.1.0-Linux-x86_64.sh#af3225ccbe8df0ffb918939e009aa57740e35058ebf9dfcf5fec794a77556c3c" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.1.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.1.0-MacOSX-x86_64.sh#efdb7e9d1e539cbed62dc3874b0de6a141f36684e6fbc05018e072b217e24077" "anaconda" verify_py34
+  install_script "Anaconda3-2.1.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.1.0-MacOSX-x86_64.sh#efdb7e9d1e539cbed62dc3874b0de6a141f36684e6fbc05018e072b217e24077" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.2.0
+++ b/plugins/python-build/share/python-build/anaconda3-2.2.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.2.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86.sh#223655cd256aa912dfc83ab24570e47bb3808bc3b0c6bd21b5db0fcf2750883e" "anaconda" verify_py34
+  install_script "Anaconda3-2.2.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86.sh#223655cd256aa912dfc83ab24570e47bb3808bc3b0c6bd21b5db0fcf2750883e" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.2.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86_64.sh#4aac68743e7706adb93f042f970373a6e7e087dbf4b02ac467c94ca4ce33d2d1" "anaconda" verify_py34
+  install_script "Anaconda3-2.2.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.2.0-Linux-x86_64.sh#4aac68743e7706adb93f042f970373a6e7e087dbf4b02ac467c94ca4ce33d2d1" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.2.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.2.0-MacOSX-x86_64.sh#81a2089ea6127717f146454e99ea0be2bd595193e4151bb05b4c15749b1d8124" "anaconda" verify_py34
+  install_script "Anaconda3-2.2.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.2.0-MacOSX-x86_64.sh#81a2089ea6127717f146454e99ea0be2bd595193e4151bb05b4c15749b1d8124" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.3.0
+++ b/plugins/python-build/share/python-build/anaconda3-2.3.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.3.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.3.0-Linux-x86.sh#4cc10d65c303191004ada2b6d75562c8ed84e42bf9871af06440dd956077b555" "anaconda" verify_py34
+  install_script "Anaconda3-2.3.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.3.0-Linux-x86.sh#4cc10d65c303191004ada2b6d75562c8ed84e42bf9871af06440dd956077b555" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.3.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.3.0-Linux-x86_64.sh#3be5410b2d9db45882c7de07c554cf4f1034becc274ec9074b23fd37a5c87a6f" "anaconda" verify_py34
+  install_script "Anaconda3-2.3.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.3.0-Linux-x86_64.sh#3be5410b2d9db45882c7de07c554cf4f1034becc274ec9074b23fd37a5c87a6f" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.3.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.3.0-MacOSX-x86_64.sh#6a0c94a49f41f9fda0138c8e966bd7b0a8965d6648fd21ffbd645d1453848ba5" "anaconda" verify_py34
+  install_script "Anaconda3-2.3.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.3.0-MacOSX-x86_64.sh#6a0c94a49f41f9fda0138c8e966bd7b0a8965d6648fd21ffbd645d1453848ba5" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.4.0
+++ b/plugins/python-build/share/python-build/anaconda3-2.4.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.4.0-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.4.0-Linux-x86.sh#f6080c6493cefc603cfeb67aaf6c3c4c6b80a66788f03db48ffd3cfa52017c0a" "anaconda" verify_py34
+  install_script "Anaconda3-2.4.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.4.0-Linux-x86.sh#f6080c6493cefc603cfeb67aaf6c3c4c6b80a66788f03db48ffd3cfa52017c0a" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.4.0-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.4.0-Linux-x86_64.sh#fb4e480059e991f2fa632b5a9bcdd284c7f0677814cd719c11d524453f96a40d" "anaconda" verify_py34
+  install_script "Anaconda3-2.4.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.4.0-Linux-x86_64.sh#fb4e480059e991f2fa632b5a9bcdd284c7f0677814cd719c11d524453f96a40d" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.4.0-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.4.0-MacOSX-x86_64.sh#f0cd785dbed0bab28dfc08a391c9de1b01633422fa317cb8365513a1ae5ae074" "anaconda" verify_py34
+  install_script "Anaconda3-2.4.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.4.0-MacOSX-x86_64.sh#f0cd785dbed0bab28dfc08a391c9de1b01633422fa317cb8365513a1ae5ae074" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.4.1
+++ b/plugins/python-build/share/python-build/anaconda3-2.4.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Anaconda3-2.4.1-Linux-x86" "http://repo.continuum.io/archive/Anaconda3-2.4.1-Linux-x86.sh#00d13413f5b8129e863dabcc2296a181c697056c5ed210739a0aa06454ab7038" "anaconda" verify_py34
+  install_script "Anaconda3-2.4.1-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.4.1-Linux-x86.sh#00d13413f5b8129e863dabcc2296a181c697056c5ed210739a0aa06454ab7038" "anaconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Anaconda3-2.4.1-Linux-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.4.1-Linux-x86_64.sh#0735e69199fc37135930ea2fd4fb6ad0adef215a2a7ba9fd6b0a0a4daaadb1cf" "anaconda" verify_py34
+  install_script "Anaconda3-2.4.1-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.4.1-Linux-x86_64.sh#0735e69199fc37135930ea2fd4fb6ad0adef215a2a7ba9fd6b0a0a4daaadb1cf" "anaconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Anaconda3-2.4.1-MacOSX-x86_64" "http://repo.continuum.io/archive/Anaconda3-2.4.1-MacOSX-x86_64.sh#22a3267638da9b7d64210d7da90d8762da7948234c21c0010a74f2621ee0ef68" "anaconda" verify_py34
+  install_script "Anaconda3-2.4.1-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.4.1-MacOSX-x86_64.sh#22a3267638da9b7d64210d7da90d8762da7948234c21c0010a74f2621ee0ef68" "anaconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/anaconda3-2.5.0
+++ b/plugins/python-build/share/python-build/anaconda3-2.5.0
@@ -1,0 +1,19 @@
+case "$(anaconda_architecture 2>/dev/null || true)" in
+"Linux-x86" )
+  install_script "Anaconda3-2.5.0-Linux-x86" "https://repo.continuum.io/archive/Anaconda3-2.5.0-Linux-x86.sh#22ac26c8bde7c4153ea859f6f6d8aca93bbf1e213d800167ad5ea530c62959af" "anaconda" verify_py35
+  ;;
+"Linux-x86_64" )
+  install_script "Anaconda3-2.5.0-Linux-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.5.0-Linux-x86_64.sh#addadcb927f15cb0b5b6e36890563d3352a8ff6a901ea753d389047d274a29a9" "anaconda" verify_py35
+  ;;
+"MacOSX-x86_64" )
+  install_script "Anaconda3-2.5.0-MacOSX-x86_64" "https://repo.continuum.io/archive/Anaconda3-2.5.0-MacOSX-x86_64.sh#9bb0f926927db210f8c2a8de881213d1a44c7b3d6dbcb93dfa6b99ed4bbd3e61" "anaconda" verify_py35
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of Anaconda3 is not available for $(anaconda_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/miniconda-2.2.2
+++ b/plugins/python-build/share/python-build/miniconda-2.2.2
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-2.2.2-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86.sh#c6c7847066dbf459f3934f7fc870d2b0919cf2cbdad78601e85c2c720daadc9d" "miniconda" verify_py27
+  install_script "Miniconda-2.2.2-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86.sh#c6c7847066dbf459f3934f7fc870d2b0919cf2cbdad78601e85c2c720daadc9d" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-2.2.2-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh#1cb05546029363279b0d6be5d66e7254b7e2b52637a02601483771f6248dde43" "miniconda" verify_py27
+  install_script "Miniconda-2.2.2-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-2.2.2-Linux-x86_64.sh#1cb05546029363279b0d6be5d66e7254b7e2b52637a02601483771f6248dde43" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-2.2.2-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-2.2.2-MacOSX-x86_64.sh#69139f6c3988b9dc7900e8e65a1f265745b185b6a60e577fe2fd4ff84646c94e" "miniconda" verify_py27
+  install_script "Miniconda-2.2.2-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-2.2.2-MacOSX-x86_64.sh#69139f6c3988b9dc7900e8e65a1f265745b185b6a60e577fe2fd4ff84646c94e" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.0.0
+++ b/plugins/python-build/share/python-build/miniconda-3.0.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.0.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.0.0-Linux-x86.sh#ffd2fb01d0c379d5e11a07f0712ebbddae73f24fe266d1af3c3fd93cc383ca8b" "miniconda" verify_py27
+  install_script "Miniconda-3.0.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.0.0-Linux-x86.sh#ffd2fb01d0c379d5e11a07f0712ebbddae73f24fe266d1af3c3fd93cc383ca8b" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.0.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.0.0-Linux-x86_64.sh#09b3a81ea0421260ae5f8a1ba8a6a21b1e9f0c745d43b997010f11ad1920dbe3" "miniconda" verify_py27
+  install_script "Miniconda-3.0.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.0.0-Linux-x86_64.sh#09b3a81ea0421260ae5f8a1ba8a6a21b1e9f0c745d43b997010f11ad1920dbe3" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.0.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.0.0-MacOSX-x86_64.sh#8f825d04146a8229154c54cf07e9cafd9b1fe44dbcfe92c36020a502489e04da" "miniconda" verify_py27
+  install_script "Miniconda-3.0.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.0.0-MacOSX-x86_64.sh#8f825d04146a8229154c54cf07e9cafd9b1fe44dbcfe92c36020a502489e04da" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.0.4
+++ b/plugins/python-build/share/python-build/miniconda-3.0.4
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.0.4-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.0.4-Linux-x86.sh#b3f392e042469a598e2cd74886d1e15c4708e190a4b188f50fa61c057d7a0ffe" "miniconda" verify_py27
+  install_script "Miniconda-3.0.4-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.0.4-Linux-x86.sh#b3f392e042469a598e2cd74886d1e15c4708e190a4b188f50fa61c057d7a0ffe" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.0.4-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.0.4-Linux-x86_64.sh#39f75a6d1619109b96756b4882d962ee12e40e07aa6d662eec10a88f19950eaa" "miniconda" verify_py27
+  install_script "Miniconda-3.0.4-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.0.4-Linux-x86_64.sh#39f75a6d1619109b96756b4882d962ee12e40e07aa6d662eec10a88f19950eaa" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.0.4-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.0.4-MacOSX-x86_64.sh#a457695a2c1216ee91f23d6a1cf2a911178382ee25fd5166ad21d45d5e57de5b" "miniconda" verify_py27
+  install_script "Miniconda-3.0.4-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.0.4-MacOSX-x86_64.sh#a457695a2c1216ee91f23d6a1cf2a911178382ee25fd5166ad21d45d5e57de5b" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.0.5
+++ b/plugins/python-build/share/python-build/miniconda-3.0.5
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.0.5-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86.sh#7f1b78d7380c664f65d811e76f3515c46689947634752e711693202a7451b85b" "miniconda" verify_py27
+  install_script "Miniconda-3.0.5-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86.sh#7f1b78d7380c664f65d811e76f3515c46689947634752e711693202a7451b85b" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.0.5-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86_64.sh#5439a10dc7ff66fa48f5b40290adfad01e58db3b03317d87f90aaf72deda862a" "miniconda" verify_py27
+  install_script "Miniconda-3.0.5-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.0.5-Linux-x86_64.sh#5439a10dc7ff66fa48f5b40290adfad01e58db3b03317d87f90aaf72deda862a" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.0.5-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.0.5-MacOSX-x86_64.sh#5ba297923cb06ed7077c4ee5e4213bc7db2878dbec9ccba1d4c9c61d5e2697ee" "miniconda" verify_py27
+  install_script "Miniconda-3.0.5-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.0.5-MacOSX-x86_64.sh#5ba297923cb06ed7077c4ee5e4213bc7db2878dbec9ccba1d4c9c61d5e2697ee" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.10.1
+++ b/plugins/python-build/share/python-build/miniconda-3.10.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.10.1-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.10.1-Linux-x86.sh#509ee56f1590705472fdac4a00aa7191f79a6a09daf4af088e92f93c648d815e" "miniconda" verify_py27
+  install_script "Miniconda-3.10.1-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.10.1-Linux-x86.sh#509ee56f1590705472fdac4a00aa7191f79a6a09daf4af088e92f93c648d815e" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.10.1-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.10.1-Linux-x86_64.sh#363f56f5608d1552325549e7371fcf460c5ed45484eb300058e3b99c997808b5" "miniconda" verify_py27
+  install_script "Miniconda-3.10.1-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.10.1-Linux-x86_64.sh#363f56f5608d1552325549e7371fcf460c5ed45484eb300058e3b99c997808b5" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.10.1-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.10.1-MacOSX-x86_64.sh#61a1e468a79cca45a518b1760033e7af89108bf88487afead79f96e3229b422a" "miniconda" verify_py27
+  install_script "Miniconda-3.10.1-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.10.1-MacOSX-x86_64.sh#61a1e468a79cca45a518b1760033e7af89108bf88487afead79f96e3229b422a" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.16.0
+++ b/plugins/python-build/share/python-build/miniconda-3.16.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.16.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86.sh#57e9659848e6322cb18c1c4a5c844a4f7dc5e784dbd8977245769ff9db28dade" "miniconda" verify_py27
+  install_script "Miniconda-3.16.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86.sh#57e9659848e6322cb18c1c4a5c844a4f7dc5e784dbd8977245769ff9db28dade" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.16.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh#b1facded0d33850e3a467d6e4589830be477bd4f819407b99b033a4d22601e4d" "miniconda" verify_py27
+  install_script "Miniconda-3.16.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.16.0-Linux-x86_64.sh#b1facded0d33850e3a467d6e4589830be477bd4f819407b99b033a4d22601e4d" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.16.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.16.0-MacOSX-x86_64.sh#e93517696d4ede4f8ff21ea42272f24508023b83f1e2e2c989d1b32ab19347a9" "miniconda" verify_py27
+  install_script "Miniconda-3.16.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.16.0-MacOSX-x86_64.sh#e93517696d4ede4f8ff21ea42272f24508023b83f1e2e2c989d1b32ab19347a9" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.3.0
+++ b/plugins/python-build/share/python-build/miniconda-3.3.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.3.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.3.0-Linux-x86.sh#415119946afab438ee2ec9d9cd063977da780029d5561d2558101233913f226a" "miniconda" verify_py27
+  install_script "Miniconda-3.3.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.3.0-Linux-x86.sh#415119946afab438ee2ec9d9cd063977da780029d5561d2558101233913f226a" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.3.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.3.0-Linux-x86_64.sh#e071ff3ffb9b4df65edf5e780d576c901753fecccd10e5af629138036aa51de3" "miniconda" verify_py27
+  install_script "Miniconda-3.3.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.3.0-Linux-x86_64.sh#e071ff3ffb9b4df65edf5e780d576c901753fecccd10e5af629138036aa51de3" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.3.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.3.0-MacOSX-x86_64.sh#9e9a65c69a1f4ec3b4df05f477b517dfa1088182344bfe8009f58d0b4bd00e5c" "miniconda" verify_py27
+  install_script "Miniconda-3.3.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.3.0-MacOSX-x86_64.sh#9e9a65c69a1f4ec3b4df05f477b517dfa1088182344bfe8009f58d0b4bd00e5c" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.4.2
+++ b/plugins/python-build/share/python-build/miniconda-3.4.2
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.4.2-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86.sh#f198359f0b34f7efa704235d24126160930b7ea7205127880f3acb0a47999413" "miniconda" verify_py27
+  install_script "Miniconda-3.4.2-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86.sh#f198359f0b34f7efa704235d24126160930b7ea7205127880f3acb0a47999413" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.4.2-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh#97d4e234f6abca0c53c606b8a7a73b909cc05a7703c512f4ea855de83b753db1" "miniconda" verify_py27
+  install_script "Miniconda-3.4.2-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.4.2-Linux-x86_64.sh#97d4e234f6abca0c53c606b8a7a73b909cc05a7703c512f4ea855de83b753db1" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.4.2-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.4.2-MacOSX-x86_64.sh#f428977cbef0d5b78379d886735c75e446a482ecb6b5605837d6c2738ddcd074" "miniconda" verify_py27
+  install_script "Miniconda-3.4.2-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.4.2-MacOSX-x86_64.sh#f428977cbef0d5b78379d886735c75e446a482ecb6b5605837d6c2738ddcd074" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.7.0
+++ b/plugins/python-build/share/python-build/miniconda-3.7.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.7.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86.sh#cada23bbaab6f21053d45f6d76cf311dffb2f234659fcef0b6a33a6d769317cb" "miniconda" verify_py27
+  install_script "Miniconda-3.7.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86.sh#cada23bbaab6f21053d45f6d76cf311dffb2f234659fcef0b6a33a6d769317cb" "miniconda" verify_py27
 ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.7.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh#ed6fd3f85dc43ca10e41355bf3efc40bffd64f2364aecad24ac68a9f1009a469" "miniconda" verify_py27
+  install_script "Miniconda-3.7.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.7.0-Linux-x86_64.sh#ed6fd3f85dc43ca10e41355bf3efc40bffd64f2364aecad24ac68a9f1009a469" "miniconda" verify_py27
 ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.7.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.7.0-MacOSX-x86_64.sh#9a8e731a2a3bd6ab3d5b7304c3c783c04582386142fe39ceb7d5bfabdd74d8eb" "miniconda" verify_py27
+  install_script "Miniconda-3.7.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.7.0-MacOSX-x86_64.sh#9a8e731a2a3bd6ab3d5b7304c3c783c04582386142fe39ceb7d5bfabdd74d8eb" "miniconda" verify_py27
 ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.8.3
+++ b/plugins/python-build/share/python-build/miniconda-3.8.3
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.8.3-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86.sh#253a95fac2dbcc01ad5ce5a78d241a362482e1fbb24b1000ea5e217f55825cb6" "miniconda" verify_py27
+  install_script "Miniconda-3.8.3-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86.sh#253a95fac2dbcc01ad5ce5a78d241a362482e1fbb24b1000ea5e217f55825cb6" "miniconda" verify_py27
 ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.8.3-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh#7ac19397731ffb212ed5534c29cd25f5f4c0c81669707ba6da8635cf1431c114" "miniconda" verify_py27
+  install_script "Miniconda-3.8.3-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.8.3-Linux-x86_64.sh#7ac19397731ffb212ed5534c29cd25f5f4c0c81669707ba6da8635cf1431c114" "miniconda" verify_py27
 ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.8.3-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.8.3-MacOSX-x86_64.sh#e19e16b7969fb256d68f7de3a4e02331ba04e1c48a262d2b9f66db106e016257" "miniconda" verify_py27
+  install_script "Miniconda-3.8.3-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.8.3-MacOSX-x86_64.sh#e19e16b7969fb256d68f7de3a4e02331ba04e1c48a262d2b9f66db106e016257" "miniconda" verify_py27
 ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-3.9.1
+++ b/plugins/python-build/share/python-build/miniconda-3.9.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda-3.9.1-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86.sh#f3cdc8d774acce05462eb07d2676162c519e1e5d35c98d1dc3d6eb7b262da0b2" "miniconda" verify_py27
+  install_script "Miniconda-3.9.1-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86.sh#f3cdc8d774acce05462eb07d2676162c519e1e5d35c98d1dc3d6eb7b262da0b2" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-3.9.1-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh#64f2b5047f944bb9b06e46c7281e9edffd412981c93e31d4c111287a1d30fef4" "miniconda" verify_py27
+  install_script "Miniconda-3.9.1-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.9.1-Linux-x86_64.sh#64f2b5047f944bb9b06e46c7281e9edffd412981c93e31d4c111287a1d30fef4" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-3.9.1-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-3.9.1-MacOSX-x86_64.sh#ea529626cfb3519eebee83c40965f0a58375e0826c6777b759eb0c42ca9970d2" "miniconda" verify_py27
+  install_script "Miniconda-3.9.1-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-3.9.1-MacOSX-x86_64.sh#ea529626cfb3519eebee83c40965f0a58375e0826c6777b759eb0c42ca9970d2" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda-latest
+++ b/plugins/python-build/share/python-build/miniconda-latest
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-armv7l" )
-  install_script "Miniconda-latest-Linux-armv7l" "http://repo.continuum.io/miniconda/Miniconda-latest-Linux-armv7l.sh" "miniconda" verify_py27
+  install_script "Miniconda-latest-Linux-armv7l" "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-armv7l.sh" "miniconda" verify_py27
   ;;
 "Linux-ppc64le" )
-  install_script "Miniconda-latest-Linux-ppc64le" "http://repo.continuum.io/miniconda/Miniconda-latest-Linux-ppc64le.sh" "miniconda" verify_py27
+  install_script "Miniconda-latest-Linux-ppc64le" "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-ppc64le.sh" "miniconda" verify_py27
   ;;
 "Linux-x86" )
-  install_script "Miniconda-latest-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86.sh" "miniconda" verify_py27
+  install_script "Miniconda-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86.sh" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda-latest-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh" "miniconda" verify_py27
+  install_script "Miniconda-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda-latest-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh" "miniconda" verify_py27
+  install_script "Miniconda-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda-latest-MacOSX-x86_64.sh" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda2-3.18.3
+++ b/plugins/python-build/share/python-build/miniconda2-3.18.3
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda2-3.18.3-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda2-3.18.3-Linux-x86.sh#1eceb3a763ab784af41a46dfd96a520659957b5fefdc1f4d53f00de43b539be0" "miniconda" verify_py27
+  install_script "Miniconda2-3.18.3-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-3.18.3-Linux-x86.sh#1eceb3a763ab784af41a46dfd96a520659957b5fefdc1f4d53f00de43b539be0" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda2-3.18.3-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda2-3.18.3-Linux-x86_64.sh#dd16e093aec2346af4e8f383a9dedb9a3d6c1a0cb7637b180e1e0790dfa55e81" "miniconda" verify_py27
+  install_script "Miniconda2-3.18.3-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-3.18.3-Linux-x86_64.sh#dd16e093aec2346af4e8f383a9dedb9a3d6c1a0cb7637b180e1e0790dfa55e81" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda2-3.18.3-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda2-3.18.3-MacOSX-x86_64.sh#c90b37e4ba866ac2195ddf9ffe5549311279041def27ade29f661f5707d43c94" "miniconda" verify_py27
+  install_script "Miniconda2-3.18.3-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-3.18.3-MacOSX-x86_64.sh#c90b37e4ba866ac2195ddf9ffe5549311279041def27ade29f661f5707d43c94" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda2-3.19.0
+++ b/plugins/python-build/share/python-build/miniconda2-3.19.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda2-3.19.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda2-3.19.0-Linux-x86.sh#869d65bed0927ff78973947f619558ed8be282851632449631d1923e3ac814d6" "miniconda" verify_py27
+  install_script "Miniconda2-3.19.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-3.19.0-Linux-x86.sh#869d65bed0927ff78973947f619558ed8be282851632449631d1923e3ac814d6" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda2-3.19.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda2-3.19.0-Linux-x86_64.sh#646b4d5398f8d76a0664375ee6226611c43ee3d49de3eb03efe7480e3c3b9ebf" "miniconda" verify_py27
+  install_script "Miniconda2-3.19.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-3.19.0-Linux-x86_64.sh#646b4d5398f8d76a0664375ee6226611c43ee3d49de3eb03efe7480e3c3b9ebf" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda2-3.19.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda2-3.19.0-MacOSX-x86_64.sh#32915acbfc8491e9fbe12b90a611a76b84e15f2cdef5272f576bfe77a4ef7061" "miniconda" verify_py27
+  install_script "Miniconda2-3.19.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-3.19.0-MacOSX-x86_64.sh#32915acbfc8491e9fbe12b90a611a76b84e15f2cdef5272f576bfe77a4ef7061" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda2-latest
+++ b/plugins/python-build/share/python-build/miniconda2-latest
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda2-latest-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86.sh" "miniconda" verify_py27
+  install_script "Miniconda2-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86.sh" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda2-latest-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" "miniconda" verify_py27
+  install_script "Miniconda2-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-latest-Linux-x86_64.sh" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda2-latest-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh" "miniconda" verify_py27
+  install_script "Miniconda2-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda2-latest-MacOSX-x86_64.sh" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-2.2.2
+++ b/plugins/python-build/share/python-build/miniconda3-2.2.2
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-2.2.2-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86.sh#55a8d6fbd680a4959525c600f3d30475af54b338beee7cd1b44a10d8122e3ee4" "miniconda" verify_py33
+  install_script "Miniconda3-2.2.2-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86.sh#55a8d6fbd680a4959525c600f3d30475af54b338beee7cd1b44a10d8122e3ee4" "miniconda" verify_py33
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-2.2.2-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh#4fb79fd66c228e221e8e6627570c84efb785f90ede576d6697e91f906b515548" "miniconda" verify_py33
+  install_script "Miniconda3-2.2.2-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-2.2.2-Linux-x86_64.sh#4fb79fd66c228e221e8e6627570c84efb785f90ede576d6697e91f906b515548" "miniconda" verify_py33
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-2.2.2-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-2.2.2-MacOSX-x86_64.sh#040065c06fdeaade1bec67418573608763f6c8c481e0e4e6a9f267598767ab33" "miniconda" verify_py33
+  install_script "Miniconda3-2.2.2-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-2.2.2-MacOSX-x86_64.sh#040065c06fdeaade1bec67418573608763f6c8c481e0e4e6a9f267598767ab33" "miniconda" verify_py33
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.0.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.0.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.0.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.0.0-Linux-x86.sh#1280ea8cbfcbd3f2a490b094657f2af7872752629b4895b88163f6d0d50dca83" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.0.0-Linux-x86.sh#1280ea8cbfcbd3f2a490b094657f2af7872752629b4895b88163f6d0d50dca83" "miniconda" verify_py33
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.0.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.0.0-Linux-x86_64.sh#6bfa6dd73140f00b15e49a8092ec74dbbb96ad28d68a5e05dedd9b427539fcaf" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.0.0-Linux-x86_64.sh#6bfa6dd73140f00b15e49a8092ec74dbbb96ad28d68a5e05dedd9b427539fcaf" "miniconda" verify_py33
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.0.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.0.0-MacOSX-x86_64.sh#b693cfdd2c4b819cd2e977b7200277e7374bcc1578a3d1975255a28887896597" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.0.0-MacOSX-x86_64.sh#b693cfdd2c4b819cd2e977b7200277e7374bcc1578a3d1975255a28887896597" "miniconda" verify_py33
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.0.4
+++ b/plugins/python-build/share/python-build/miniconda3-3.0.4
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.0.4-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.0.4-Linux-x86.sh#1046256accc3b752f4625658e7d845d65c14c7fbb7346579ee828adf7139471d" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.4-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.0.4-Linux-x86.sh#1046256accc3b752f4625658e7d845d65c14c7fbb7346579ee828adf7139471d" "miniconda" verify_py33
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.0.4-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.0.4-Linux-x86_64.sh#afe03bbed5001a5352e81c018e0bb14e6ade2baa09ecf689febfd6edecb5e93a" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.4-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.0.4-Linux-x86_64.sh#afe03bbed5001a5352e81c018e0bb14e6ade2baa09ecf689febfd6edecb5e93a" "miniconda" verify_py33
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.0.4-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.0.4-MacOSX-x86_64.sh#986525923231b4796c1eb13f2e4defae9aad5ed09b3e32c01b7ebb0aad4ad870" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.4-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.0.4-MacOSX-x86_64.sh#986525923231b4796c1eb13f2e4defae9aad5ed09b3e32c01b7ebb0aad4ad870" "miniconda" verify_py33
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.0.5
+++ b/plugins/python-build/share/python-build/miniconda3-3.0.5
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.0.5-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.0.5-Linux-x86.sh#014d0e44b752d9e91373a3c56252b62c0f29b628a8584f8b5515c7c3d8acc6be" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.5-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.0.5-Linux-x86.sh#014d0e44b752d9e91373a3c56252b62c0f29b628a8584f8b5515c7c3d8acc6be" "miniconda" verify_py33
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.0.5-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.0.5-Linux-x86_64.sh#eaf8c5005645eecd18cc09d2da2a69314057a9e36eadc5084120bc1deffa332b" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.5-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.0.5-Linux-x86_64.sh#eaf8c5005645eecd18cc09d2da2a69314057a9e36eadc5084120bc1deffa332b" "miniconda" verify_py33
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.0.5-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.0.5-MacOSX-x86_64.sh#7c088951665e2c35574f6dde81189467d80806caff47872887525ed3d0b4dbd0" "miniconda" verify_py33
+  install_script "Miniconda3-3.0.5-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.0.5-MacOSX-x86_64.sh#7c088951665e2c35574f6dde81189467d80806caff47872887525ed3d0b4dbd0" "miniconda" verify_py33
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.10.1
+++ b/plugins/python-build/share/python-build/miniconda3-3.10.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.10.1-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.10.1-Linux-x86.sh#e9b751fa8bc5372731512e058fa3867ad9e54983b48d462b4c8f7a031953c2bc" "miniconda" verify_py34
+  install_script "Miniconda3-3.10.1-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.10.1-Linux-x86.sh#e9b751fa8bc5372731512e058fa3867ad9e54983b48d462b4c8f7a031953c2bc" "miniconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.10.1-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.10.1-Linux-x86_64.sh#cbd86f49008319416d1e57f9ac43a42445058f06aaeebe5ab974769887a8628b" "miniconda" verify_py34
+  install_script "Miniconda3-3.10.1-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.10.1-Linux-x86_64.sh#cbd86f49008319416d1e57f9ac43a42445058f06aaeebe5ab974769887a8628b" "miniconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.10.1-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.10.1-MacOSX-x86_64.sh#58ba40cbd1cf5bba680f94321d2ce22685a2b06ad9252044f06a0018fe99bd62" "miniconda" verify_py34
+  install_script "Miniconda3-3.10.1-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.10.1-MacOSX-x86_64.sh#58ba40cbd1cf5bba680f94321d2ce22685a2b06ad9252044f06a0018fe99bd62" "miniconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.16.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.16.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.16.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86.sh#faedb7a75584d48d563f0f9b449cb00bf8d05ddb3e1ede1936bf522f03f0e1e2" "miniconda" verify_py34
+  install_script "Miniconda3-3.16.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86.sh#faedb7a75584d48d563f0f9b449cb00bf8d05ddb3e1ede1936bf522f03f0e1e2" "miniconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.16.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh#3becbcdd36761711850cffa11064b87cfe067dbeb4a5eda544dc341af482de87" "miniconda" verify_py34
+  install_script "Miniconda3-3.16.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.16.0-Linux-x86_64.sh#3becbcdd36761711850cffa11064b87cfe067dbeb4a5eda544dc341af482de87" "miniconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.16.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.16.0-MacOSX-x86_64.sh#36fe954548a6900249270f9632b76252e247313cc9d551c096d7e1f526a88631" "miniconda" verify_py34
+  install_script "Miniconda3-3.16.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.16.0-MacOSX-x86_64.sh#36fe954548a6900249270f9632b76252e247313cc9d551c096d7e1f526a88631" "miniconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.18.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.18.3
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.18.3-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.18.3-Linux-x86.sh#7f6b432daacfbe67ac5fd5b3e3bc5bca75642e4e099e967b1353a5b0a828b036" "miniconda" verify_py27
+  install_script "Miniconda3-3.18.3-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.18.3-Linux-x86.sh#7f6b432daacfbe67ac5fd5b3e3bc5bca75642e4e099e967b1353a5b0a828b036" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.18.3-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.18.3-Linux-x86_64.sh#6eee19f7ac958578b0da4124f58b09f23422fa6f6b26af8b594a47f08cc61af4" "miniconda" verify_py27
+  install_script "Miniconda3-3.18.3-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.18.3-Linux-x86_64.sh#6eee19f7ac958578b0da4124f58b09f23422fa6f6b26af8b594a47f08cc61af4" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.18.3-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.18.3-MacOSX-x86_64.sh#b81c9b27eb9a91e3183e51000dbf986bfe91f99acfa1a4e3bc849ddacc7bf934" "miniconda" verify_py27
+  install_script "Miniconda3-3.18.3-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.18.3-MacOSX-x86_64.sh#b81c9b27eb9a91e3183e51000dbf986bfe91f99acfa1a4e3bc849ddacc7bf934" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.19.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.19.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.19.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86.sh#9789463cad35cdb3ee4cda5a9c3767cad21491faacc071fcd60eb38a9f75098e" "miniconda" verify_py27
+  install_script "Miniconda3-3.19.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86.sh#9789463cad35cdb3ee4cda5a9c3767cad21491faacc071fcd60eb38a9f75098e" "miniconda" verify_py27
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.19.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86_64.sh#9ea57c0fdf481acf89d816184f969b04bc44dea27b258c4e86b1e3a25ff26aa0" "miniconda" verify_py27
+  install_script "Miniconda3-3.19.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.19.0-Linux-x86_64.sh#9ea57c0fdf481acf89d816184f969b04bc44dea27b258c4e86b1e3a25ff26aa0" "miniconda" verify_py27
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.19.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.19.0-MacOSX-x86_64.sh#40ec9c2726262addd330c24f62853de47430482965f0bb8cba47d8cd995bec29" "miniconda" verify_py27
+  install_script "Miniconda3-3.19.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.19.0-MacOSX-x86_64.sh#40ec9c2726262addd330c24f62853de47430482965f0bb8cba47d8cd995bec29" "miniconda" verify_py27
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.3.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.3.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.3.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.3.0-Linux-x86.sh#80957b9c4b8d5674e13693cdf6be3e73ff1a109fa26faaefd4f0dbeb11a57295" "miniconda" verify_py33
+  install_script "Miniconda3-3.3.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.3.0-Linux-x86.sh#80957b9c4b8d5674e13693cdf6be3e73ff1a109fa26faaefd4f0dbeb11a57295" "miniconda" verify_py33
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.3.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.3.0-Linux-x86_64.sh#07fbf1b54c7a03a524a34ec0078d4c39499fe7cdf3dce209e686ef5e0433722f" "miniconda" verify_py33
+  install_script "Miniconda3-3.3.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.3.0-Linux-x86_64.sh#07fbf1b54c7a03a524a34ec0078d4c39499fe7cdf3dce209e686ef5e0433722f" "miniconda" verify_py33
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.3.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.3.0-MacOSX-x86_64.sh#131b6a351987caab78410082e81d9cb51db262301cb9b8f09656bc94cddc51e4" "miniconda" verify_py33
+  install_script "Miniconda3-3.3.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.3.0-MacOSX-x86_64.sh#131b6a351987caab78410082e81d9cb51db262301cb9b8f09656bc94cddc51e4" "miniconda" verify_py33
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.4.2
+++ b/plugins/python-build/share/python-build/miniconda3-3.4.2
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.4.2-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86.sh#9629cb8f1d633d1bfff59985fa93493eae3c18590893631bc5c1ae57d880e659" "miniconda" verify_py33
+  install_script "Miniconda3-3.4.2-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86.sh#9629cb8f1d633d1bfff59985fa93493eae3c18590893631bc5c1ae57d880e659" "miniconda" verify_py33
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.4.2-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh#ea2eb831c89fedb8cd5e7d1cc4d299726684b8d8ccd0fdf16f039bd316dccf78" "miniconda" verify_py33
+  install_script "Miniconda3-3.4.2-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.4.2-Linux-x86_64.sh#ea2eb831c89fedb8cd5e7d1cc4d299726684b8d8ccd0fdf16f039bd316dccf78" "miniconda" verify_py33
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.4.2-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.4.2-MacOSX-x86_64.sh#8dbad17efb24dc04473fef911239a09e9bf4219cdcfef7b9e263f5f129a8f38d" "miniconda" verify_py33
+  install_script "Miniconda3-3.4.2-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.4.2-MacOSX-x86_64.sh#8dbad17efb24dc04473fef911239a09e9bf4219cdcfef7b9e263f5f129a8f38d" "miniconda" verify_py33
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.7.0
+++ b/plugins/python-build/share/python-build/miniconda3-3.7.0
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.7.0-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86.sh#d5143303a8159a5b7388cc1d09aa6d9bc029c2c5f8cb53230a5fcf07d9ee149c" "miniconda" verify_py34
+  install_script "Miniconda3-3.7.0-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86.sh#d5143303a8159a5b7388cc1d09aa6d9bc029c2c5f8cb53230a5fcf07d9ee149c" "miniconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.7.0-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh#dba631db9938216af83ca9793605a73fae8b8e5ef966c15b9e89c09bf405de26" "miniconda" verify_py34
+  install_script "Miniconda3-3.7.0-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.7.0-Linux-x86_64.sh#dba631db9938216af83ca9793605a73fae8b8e5ef966c15b9e89c09bf405de26" "miniconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.7.0-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.7.0-MacOSX-x86_64.sh#fd4df5a944801019ef56a348bdcb483a7fdbf376c98aeacb25a78e5bc9bb4158" "miniconda" verify_py34
+  install_script "Miniconda3-3.7.0-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.7.0-MacOSX-x86_64.sh#fd4df5a944801019ef56a348bdcb483a7fdbf376c98aeacb25a78e5bc9bb4158" "miniconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.8.3
+++ b/plugins/python-build/share/python-build/miniconda3-3.8.3
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.8.3-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86.sh#2345cf595864ee0a139f6dd1572070442445baace0dec7a4937267169708f929" "miniconda" verify_py34
+  install_script "Miniconda3-3.8.3-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86.sh#2345cf595864ee0a139f6dd1572070442445baace0dec7a4937267169708f929" "miniconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.8.3-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh#26483a27b56d3567596b866076cb6de75c4b7e376fe359720ec27fca2c05ceec" "miniconda" verify_py34
+  install_script "Miniconda3-3.8.3-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.8.3-Linux-x86_64.sh#26483a27b56d3567596b866076cb6de75c4b7e376fe359720ec27fca2c05ceec" "miniconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.8.3-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.8.3-MacOSX-x86_64.sh#86be2f1d55755670e0a21902584768b69732b31e87af22d1cca856f3d9e5c20d" "miniconda" verify_py34
+  install_script "Miniconda3-3.8.3-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.8.3-MacOSX-x86_64.sh#86be2f1d55755670e0a21902584768b69732b31e87af22d1cca856f3d9e5c20d" "miniconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-3.9.1
+++ b/plugins/python-build/share/python-build/miniconda3-3.9.1
@@ -1,12 +1,12 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-x86" )
-  install_script "Miniconda3-3.9.1-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86.sh#1a9f8abfc63080c2d764039335a24465388533cca86472224c994ed8d32c4d48" "miniconda" verify_py34
+  install_script "Miniconda3-3.9.1-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86.sh#1a9f8abfc63080c2d764039335a24465388533cca86472224c994ed8d32c4d48" "miniconda" verify_py34
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-3.9.1-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh#6c6b44acdd0bc4229377ee10d52c8ac6160c336d9cdd669db7371aa9344e1ac3" "miniconda" verify_py34
+  install_script "Miniconda3-3.9.1-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.9.1-Linux-x86_64.sh#6c6b44acdd0bc4229377ee10d52c8ac6160c336d9cdd669db7371aa9344e1ac3" "miniconda" verify_py34
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-3.9.1-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-3.9.1-MacOSX-x86_64.sh#e32523e3fdf0addab008e816c54eb6ae6eb6d62b1122d1e0dc4f4313a97b0591" "miniconda" verify_py34
+  install_script "Miniconda3-3.9.1-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-3.9.1-MacOSX-x86_64.sh#e32523e3fdf0addab008e816c54eb6ae6eb6d62b1122d1e0dc4f4313a97b0591" "miniconda" verify_py34
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/miniconda3-latest
+++ b/plugins/python-build/share/python-build/miniconda3-latest
@@ -1,18 +1,18 @@
 case "$(anaconda_architecture 2>/dev/null || true)" in
 "Linux-armv7l" )
-  install_script "Miniconda3-latest-Linux-armv7l" "http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-armv7l.sh" "miniconda" verify_py35
+  install_script "Miniconda3-latest-Linux-armv7l" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-armv7l.sh" "miniconda" verify_py35
   ;;
 "Linux-ppc64le" )
-  install_script "Miniconda3-latest-Linux-ppc64le" "http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-ppc64le.sh" "miniconda" verify_py35
+  install_script "Miniconda3-latest-Linux-ppc64le" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-ppc64le.sh" "miniconda" verify_py35
   ;;
 "Linux-x86" )
-  install_script "Miniconda3-latest-Linux-x86" "http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh" "miniconda" verify_py35
+  install_script "Miniconda3-latest-Linux-x86" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86.sh" "miniconda" verify_py35
   ;;
 "Linux-x86_64" )
-  install_script "Miniconda3-latest-Linux-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" "miniconda" verify_py35
+  install_script "Miniconda3-latest-Linux-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh" "miniconda" verify_py35
   ;;
 "MacOSX-x86_64" )
-  install_script "Miniconda3-latest-MacOSX-x86_64" "http://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" "miniconda" verify_py35
+  install_script "Miniconda3-latest-MacOSX-x86_64" "https://repo.continuum.io/miniconda/Miniconda3-latest-MacOSX-x86_64.sh" "miniconda" verify_py35
   ;;
 * )
   { echo


### PR DESCRIPTION
Download links are changed to HTTPS. This is important especially for latest version of miniconda as there is no SHA256 to keep users from MITM attack.

Anaconda 2.5.0 is added as well.