### PR TITLE
Added pypy-dev special case in pyenv-install to use py27

### DIFF
--- a/plugins/python-build/bin/pyenv-install
+++ b/plugins/python-build/bin/pyenv-install
@@ -200,7 +200,7 @@ if [ -z "${PYENV_BOOTSTRAP_VERSION}" ]; then
       done
     done
     ;;
-  "pypy-"*"-src" | "pypy3-"*"-src" )
+  "pypy-dev" | "pypy-"*"-src" | "pypy3-"*"-src" )
     # PyPy/PyPy3 requires existing Python 2.7 to build
     if [ -n "${PYENV_RPYTHON_VERSION}" ]; then
       PYENV_BOOTSTRAP_VERSION="${PYENV_RPYTHON_VERSION}"


### PR DESCRIPTION
Related to #546

pypy-dev compiles the pypy project too, so it should use a Python2.7 interpreter 