### PR TITLE
"." has been deprecated in the fish shell in favor of explicit "source"

### DIFF
--- a/libexec/pyenv-init
+++ b/libexec/pyenv-init
@@ -70,7 +70,7 @@ if [ -z "$print" ]; then
     echo
     case "$shell" in
     fish )
-      echo 'status --is-interactive; and . (pyenv init -|psub)'
+      echo 'status --is-interactive; and source (pyenv init -|psub)'
       ;;
     * )
       echo 'eval "$(pyenv init -)"'

--- a/test/init.bats
+++ b/test/init.bats
@@ -53,7 +53,7 @@ OUT
 @test "fish instructions" {
   run pyenv-init fish
   assert [ "$status" -eq 1 ]
-  assert_line 'status --is-interactive; and . (pyenv init -|psub)'
+  assert_line 'status --is-interactive; and source (pyenv init -|psub)'
 }
 
 @test "option to skip rehash" {


### PR DESCRIPTION
running the command suggested by `pyenv init` as it stands (with `.` instead of `source`) in the fish shell doesn't work - fish complains about the [deprecation](https://github.com/fish-shell/fish-shell/issues/310) and otherwise fails. this fixes the problem.