### PR TITLE
Write remote content on stdout with `aria2c`

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -340,7 +340,9 @@ http_head_aria2c() {
 }
 
 http_get_aria2c() {
-  aria2c -o "${2:--}" ${ARIA2_OPTS} "$1"
+  local out="${2:-$(mktemp "out.XXXXXX")}"
+  aria2c --allow-overwrite=true -o "${out}" ${ARIA2_OPTS} "$1" >&4
+  [ -n "$2" ] || cat "${out}"
 }
 
 http_head_curl() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -341,8 +341,11 @@ http_head_aria2c() {
 
 http_get_aria2c() {
   local out="${2:-$(mktemp "out.XXXXXX")}"
-  aria2c --allow-overwrite=true -o "${out}" ${ARIA2_OPTS} "$1" >&4
-  [ -n "$2" ] || cat "${out}"
+  if aria2c --allow-overwrite=true -o "${out}" ${ARIA2_OPTS} "$1" >&4; then
+    [ -n "$2" ] || cat "${out}"
+  else
+    false
+  fi
 }
 
 http_head_curl() {

--- a/plugins/python-build/test/cache.bats
+++ b/plugins/python-build/test/cache.bats
@@ -11,7 +11,7 @@ setup() {
 
 
 @test "packages are saved to download cache" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/without-checksum
 
@@ -59,7 +59,7 @@ setup() {
 
   stub shasum true "echo invalid" "echo $checksum"
   stub aria2c "--dry-run * : true" \
-    "-o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2"
+    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   touch "${PYTHON_BUILD_CACHE_PATH}/package-1.0.0.tar.gz"
 
@@ -76,7 +76,7 @@ setup() {
 
 
 @test "nonexistent cache directory is ignored" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   export PYTHON_BUILD_CACHE_PATH="${TMP}/nonexistent"
 

--- a/plugins/python-build/test/checksum.bats
+++ b/plugins/python-build/test/checksum.bats
@@ -7,7 +7,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 
 @test "package URL without checksum" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/without-checksum
 
@@ -20,7 +20,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -34,7 +34,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL with invalid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-invalid-checksum
 
@@ -48,7 +48,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL with checksum but no shasum support" {
   stub shasum false
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -62,7 +62,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL with valid md5 checksum" {
   stub md5 true "echo 83e6d7725e20166024a1eb74cde80677"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
@@ -76,7 +76,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL with md5 checksum but no md5 support" {
   stub md5 false
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
@@ -90,7 +90,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package with invalid checksum" {
   stub shasum true "echo invalid"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -127,7 +127,7 @@ DEF
   stub shasum true \
     "echo invalid" \
     "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   export -n PYTHON_BUILD_CACHE_PATH
   export PYTHON_BUILD_BUILD_PATH="${TMP}/build"
@@ -146,7 +146,7 @@ DEF
 }
 
 @test "package URL with checksum of unexpected length" {
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#checksum_of_unexpected_length" copy

--- a/plugins/python-build/test/mirror.bats
+++ b/plugins/python-build/test/mirror.bats
@@ -9,7 +9,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL without checksum bypasses mirror" {
   stub shasum true
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/without-checksum
   echo "$output" >&2
@@ -24,7 +24,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
 @test "package URL with checksum but no shasum support bypasses mirror" {
   stub shasum false
-  stub aria2c "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -42,7 +42,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo $checksum"
   stub aria2c "--dry-run $mirror_url : true" \
-    "-o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2"
+    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   install_fixture definitions/with-checksum
 
@@ -60,7 +60,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo $checksum"
   stub aria2c "--dry-run $mirror_url : false" \
-    "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$3"
 
   install_fixture definitions/with-checksum
 
@@ -78,8 +78,8 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo invalid" "echo $checksum"
   stub aria2c "--dry-run $mirror_url : true" \
-    "-o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2" \
-    "-o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   install_fixture definitions/with-checksum
   echo "$output" >&2
@@ -98,7 +98,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
 
   stub shasum true "echo $checksum"
   stub aria2c "--dry-run : true" \
-    "-o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$2" \
+    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
 
@@ -115,7 +115,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub aria2c "-o * https://www.python.org/* : cp $FIXTURE_ROOT/\${3##*/} \$2"
+  stub aria2c "--allow-overwrite=true -o * https://www.python.org/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "https://www.python.org/packages/package-1.0.0.tar.gz#ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5" copy


### PR DESCRIPTION
`aria2c` doesn't support writing content to stdout. As a workaround, this patch will use temporary file then write content on stdout once finished downloading.

* [x] fix tests
* [x] send similar fix to https://github.com/rbenv/ruby-build