### PR TITLE
Use `curl` stub instead of `aria2c` during tests

### DIFF
--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -8,9 +8,10 @@ export CC=cc
 export -n PYTHON_CONFIGURE_OPTS
 
 setup() {
+  ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
-  stub aria2c false
+  stub curl false
 }
 
 executable() {

--- a/plugins/python-build/test/checksum.bats
+++ b/plugins/python-build/test/checksum.bats
@@ -3,107 +3,107 @@
 load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH=
-export PYTHON_BUILD_ARIA2_OPTS=
+export PYTHON_BUILD_CURL_OPTS=
 
 
 @test "package URL without checksum" {
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
 }
 
 
 @test "package URL with valid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with invalid checksum" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-invalid-checksum
 
   assert_failure
   refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with checksum but no shasum support" {
   stub shasum false
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with valid md5 checksum" {
   stub md5 true "echo 83e6d7725e20166024a1eb74cde80677"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub md5
 }
 
 
 @test "package URL with md5 checksum but no md5 support" {
   stub md5 false
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-md5-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub md5
 }
 
 
 @test "package with invalid checksum" {
   stub shasum true "echo invalid"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_failure
   refute [ -f "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 @test "existing tarball in build location is reused" {
   stub shasum true "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c false
+  stub curl false
   stub curl false
   stub wget false
 
@@ -127,7 +127,7 @@ DEF
   stub shasum true \
     "echo invalid" \
     "echo ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   export -n PYTHON_BUILD_CACHE_PATH
   export PYTHON_BUILD_BUILD_PATH="${TMP}/build"
@@ -146,7 +146,7 @@ DEF
 }
 
 @test "package URL with checksum of unexpected length" {
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "http://example.com/packages/package-1.0.0.tar.gz#checksum_of_unexpected_length" copy

--- a/plugins/python-build/test/fetch.bats
+++ b/plugins/python-build/test/fetch.bats
@@ -5,12 +5,13 @@ export PYTHON_BUILD_SKIP_MIRROR=1
 export PYTHON_BUILD_CACHE_PATH=
 
 setup() {
+  ensure_not_found_in_path aria2c
   export PYTHON_BUILD_BUILD_PATH="${TMP}/source"
   mkdir -p "${PYTHON_BUILD_BUILD_PATH}"
 }
 
 @test "failed download displays error message" {
-  stub aria2c false
+  stub curl false
 
   install_fixture definitions/without-checksum
   assert_failure

--- a/plugins/python-build/test/hooks.bats
+++ b/plugins/python-build/test/hooks.bats
@@ -3,6 +3,7 @@
 load test_helper
 
 setup() {
+  ensure_not_found_in_path aria2c
   export PYENV_ROOT="${TMP}/pyenv"
   export HOOK_PATH="${TMP}/i has hooks"
   mkdir -p "$HOOK_PATH"

--- a/plugins/python-build/test/mirror.bats
+++ b/plugins/python-build/test/mirror.bats
@@ -4,12 +4,12 @@ load test_helper
 export PYTHON_BUILD_SKIP_MIRROR=
 export PYTHON_BUILD_CACHE_PATH=
 export PYTHON_BUILD_MIRROR_URL=http://mirror.example.com
-export PYTHON_BUILD_ARIA2_OPTS=
+export PYTHON_BUILD_CURL_OPTS=
 
 
 @test "package URL without checksum bypasses mirror" {
   stub shasum true
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/without-checksum
   echo "$output" >&2
@@ -17,21 +17,21 @@ export PYTHON_BUILD_ARIA2_OPTS=
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
 
 @test "package URL with checksum but no shasum support bypasses mirror" {
   stub shasum false
-  stub aria2c "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -41,15 +41,15 @@ export PYTHON_BUILD_ARIA2_OPTS=
   local mirror_url="${PYTHON_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--dry-run $mirror_url : true" \
-    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
+  stub curl "-*I* $mirror_url : true" \
+    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -59,15 +59,15 @@ export PYTHON_BUILD_ARIA2_OPTS=
   local mirror_url="${PYTHON_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--dry-run $mirror_url : false" \
-    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${3##*/} \$3"
+  stub curl "-*I* $mirror_url : false" \
+    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -77,9 +77,9 @@ export PYTHON_BUILD_ARIA2_OPTS=
   local mirror_url="${PYTHON_BUILD_MIRROR_URL}/$checksum"
 
   stub shasum true "echo invalid" "echo $checksum"
-  stub aria2c "--dry-run $mirror_url : true" \
-    "--allow-overwrite=true -o * $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
-    "--allow-overwrite=true -o * http://example.com/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-*I* $mirror_url : true" \
+    "-q -o * -*S* $mirror_url : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+    "-q -o * -*S* http://example.com/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   install_fixture definitions/with-checksum
   echo "$output" >&2
@@ -87,7 +87,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -97,15 +97,15 @@ export PYTHON_BUILD_ARIA2_OPTS=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--dry-run : true" \
-    "--allow-overwrite=true -o * https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
+  stub curl "-*I* : true" \
+    "-q -o * -*S* https://?*/$checksum : cp $FIXTURE_ROOT/package-1.0.0.tar.gz \$3" \
 
   install_fixture definitions/with-checksum
 
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }
 
@@ -115,7 +115,7 @@ export PYTHON_BUILD_ARIA2_OPTS=
   local checksum="ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5"
 
   stub shasum true "echo $checksum"
-  stub aria2c "--allow-overwrite=true -o * https://www.python.org/* : cp $FIXTURE_ROOT/\${4##*/} \$3"
+  stub curl "-q -o * -*S* https://www.python.org/* : cp $FIXTURE_ROOT/\${5##*/} \$3"
 
   run_inline_definition <<DEF
 install_package "package-1.0.0" "https://www.python.org/packages/package-1.0.0.tar.gz#ba988b1bb4250dee0b9dd3d4d722f9c64b2bacfc805d1b6eba7426bda72dd3c5" copy
@@ -124,6 +124,6 @@ DEF
   assert_success
   assert [ -x "${INSTALL_ROOT}/bin/package" ]
 
-  unstub aria2c
+  unstub curl
   unstub shasum
 }

--- a/plugins/python-build/test/pyenv.bats
+++ b/plugins/python-build/test/pyenv.bats
@@ -4,6 +4,7 @@ load test_helper
 export PYENV_ROOT="${TMP}/pyenv"
 
 setup() {
+  ensure_not_found_in_path aria2c
   stub pyenv-hooks 'install : true'
   stub pyenv-rehash 'true'
 }

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -9,9 +9,10 @@ export CC=cc
 export TMP_FIXTURES="$TMP/fixtures"
 
 setup() {
+  ensure_not_found_in_path aria2c
   mkdir -p "$INSTALL_ROOT"
   stub md5 false
-  stub aria2c false
+  stub curl false
 }
 
 executable() {

--- a/plugins/python-build/test/test_helper.bash
+++ b/plugins/python-build/test/test_helper.bash
@@ -9,6 +9,39 @@ if [ "$FIXTURE_ROOT" != "$BATS_TEST_DIRNAME/fixtures" ]; then
   export PATH
 fi
 
+remove_command_from_path() {
+  OLDIFS="${IFS}"
+  local cmd="$1"
+  local path
+  local paths=()
+  IFS=:
+  for path in ${PATH}; do
+    if [ -e "${path}/${cmd}" ]; then
+      local tmp_path="$(mktemp -d "${TMP}/path.XXXXX")"
+      ln -fs "${path}"/* "${tmp_path}"
+      rm -f "${tmp_path}/${cmd}"
+      paths["${#paths[@]}"]="${tmp_path}"
+    else
+      paths["${#paths[@]}"]="${path}"
+    fi
+  done
+  export PATH="${paths[*]}"
+  IFS="${OLDIFS}"
+}
+
+ensure_not_found_in_path() {
+  local cmd
+  for cmd; do
+    if command -v "${cmd}" 1>/dev/null 2>&1; then
+      remove_command_from_path "${cmd}"
+    fi
+  done
+}
+
+setup() {
+  ensure_not_found_in_path aria2c
+}
+
 teardown() {
   rm -fr "${TMP:?}"/*
 }


### PR DESCRIPTION
Sometime `aria2c` requires some _special_ customization (e.g. #620) to call it. Using `curl` during tests could make test impl simpler and understandable..