### PR TITLE
Added `build_package_symlink_version_suffix` to stop calling `verify_pyXX`

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1462,38 +1462,44 @@ apply_python_patch() {
   esac
 }
 
-verify_python() {
-  if [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then
+build_package_symlink_version_suffix() {
+  if [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]] && [ ! -e "${PREFIX_PATH}/bin" ]; then
     # Only symlinks are installed in ${PREFIX_PATH}/bin
-    rm -fr "${PREFIX_PATH}/bin"
     ln -fs "${PREFIX_PATH}/Python.framework/Versions/Current/bin" "${PREFIX_PATH}/bin"
   fi
 
   # Not create symlinks on `altinstall` (#255)
   if [[ "$PYTHON_MAKE_INSTALL_TARGET" != *"altinstall"* ]]; then
-    local suffix="${1#python}"
-    local file link
     shopt -s nullglob
-    for file in "${PREFIX_PATH}/bin"/*; do
-      unset link
-      case "${file}" in
-      */"python${suffix}-config" )
-        # Symlink `pythonX.Y-config` to `python-config` if `python-config` is missing (#296)
-        link="${file%/*}/python-config"
-      ;;
-      */*"-${suffix}" )
-        link="${file%%-${suffix}}"
-      ;;
-      */*"${suffix}" )
-        link="${file%%${suffix}}"
-      ;;
-      esac
-      if [ -n "$link" ] && [ ! -e "$link" ]; then
-        ( cd "${file%/*}" && ln -fs "${file##*/}" "${link##*/}" )
-      fi
-    done
+    local version_bin="$(ls -1 "${PREFIX_PATH}/bin/python"* | grep '[0-9]$' | sort | tail -1)"
+    suffix="$(basename "${version_bin}" | sed -e 's/^python//')"
+    if [ -n "${suffix}" ]; then
+      local file link
+      for file in "${PREFIX_PATH}/bin"/*; do
+        unset link
+        case "${file}" in
+        */"python${suffix}-config" )
+          # Symlink `pythonX.Y-config` to `python-config` if `python-config` is missing (#296)
+          link="${file%/*}/python-config"
+        ;;
+        */*"-${suffix}" )
+          link="${file%%-${suffix}}"
+        ;;
+        */*"${suffix}" )
+          link="${file%%${suffix}}"
+        ;;
+        esac
+        if [ -n "$link" ] && [ ! -e "$link" ]; then
+          ( cd "${file%/*}" && ln -fs "${file##*/}" "${link##*/}" )
+        fi
+      done
+    fi
     shopt -u nullglob
   fi
+}
+
+verify_python() {
+  build_package_symlink_version_suffix
 
   if [ ! -x "${PYTHON_BIN}" ]; then
     { colorize 1 "ERROR"
@@ -1643,6 +1649,7 @@ build_package_ez_setup() {
     echo "error: failed to install setuptools via ez_setup.py" >&2
     return 1
   }
+  build_package_symlink_version_suffix
 }
 
 build_package_get_pip() {
@@ -1661,6 +1668,7 @@ build_package_get_pip() {
     echo "error: failed to install pip via get-pip.py" >&2
     return 1
   }
+  build_package_symlink_version_suffix
 }
 
 build_package_ensurepip() {
@@ -1671,6 +1679,7 @@ build_package_ensurepip() {
   fi
   # FIXME: `--altinstall` with `get-pip.py`
   "$PYTHON_BIN" -s -m ensurepip ${ensurepip_opts} 1>/dev/null 2>&1 || build_package_get_pip "$@" || return 1
+  build_package_symlink_version_suffix
 }
 
 version() {

--- a/plugins/python-build/share/python-build/2.6.6
+++ b/plugins/python-build/share/python-build/2.6.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.6" "http://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" ldflags_dirs standard verify_py26 ensurepip verify_py26
+install_package "Python-2.6.6" "http://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.7
+++ b/plugins/python-build/share/python-build/2.6.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.7" "http://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" ldflags_dirs standard verify_py26 ensurepip verify_py26
+install_package "Python-2.6.7" "http://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.8
+++ b/plugins/python-build/share/python-build/2.6.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.8" "http://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" ldflags_dirs standard verify_py26 ensurepip verify_py26
+install_package "Python-2.6.8" "http://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.9
+++ b/plugins/python-build/share/python-build/2.6.9
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.9" "http://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" ldflags_dirs standard verify_py26 ensurepip verify_py26
+install_package "Python-2.6.9" "http://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.7
+++ b/plugins/python-build/share/python-build/2.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7" "http://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7" "http://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-2.7-dev" "https://hg.python.org/cpython" "2.7" standard verify_py27 ensurepip verify_py27
+install_hg "Python-2.7-dev" "https://hg.python.org/cpython" "2.7" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.1" "http://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.1" "http://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.12rc1
+++ b/plugins/python-build/share/python-build/2.7.12rc1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.12rc1" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12rc1.tgz#83f5cdbbb3494753d0e1ed2a093942c1ddcd04264af5e7d6183c7f7c64ffd33c" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.12rc1" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12rc1.tgz#83f5cdbbb3494753d0e1ed2a093942c1ddcd04264af5e7d6183c7f7c64ffd33c" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.2" "http://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.2" "http://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.3" "http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.3" "http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.4" "http://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.4" "http://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.5" "http://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.5" "http://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.6" "http://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.6" "http://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/3.3-dev
+++ b/plugins/python-build/share/python-build/3.3-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-3.3-dev" "https://hg.python.org/cpython" "3.3" standard verify_py33 ensurepip verify_py33
+install_hg "Python-3.3-dev" "https://hg.python.org/cpython" "3.3" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.0
+++ b/plugins/python-build/share/python-build/3.3.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.0" "http://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.0" "http://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.1
+++ b/plugins/python-build/share/python-build/3.3.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.1" "http://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.1" "http://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.2
+++ b/plugins/python-build/share/python-build/3.3.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.2" "http://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.2" "http://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.3
+++ b/plugins/python-build/share/python-build/3.3.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.3" "http://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.3" "http://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.4
+++ b/plugins/python-build/share/python-build/3.3.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.4" "http://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.4" "http://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.5
+++ b/plugins/python-build/share/python-build/3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.5" "http://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.5" "http://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.6
+++ b/plugins/python-build/share/python-build/3.3.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tgz#0a58ad1f1def4ecc90b18b0c410a3a0e1a48cf7692c75d1f83d0af080e5d2034" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tgz#0a58ad1f1def4ecc90b18b0c410a3a0e1a48cf7692c75d1f83d0af080e5d2034" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-3.4-dev" "https://hg.python.org/cpython" "3.4" standard verify_py34 ensurepip verify_py34
+install_hg "Python-3.4-dev" "https://hg.python.org/cpython" "3.4" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz#d2c83ea0217769a73e8b1ee33ffbca814903f8568e30f8d13e68e3d1f743449c" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz#d2c83ea0217769a73e8b1ee33ffbca814903f8568e30f8d13e68e3d1f743449c" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.1
+++ b/plugins/python-build/share/python-build/3.4.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz#8d007e3ef80b128a292be101201e75dec5480e5632e994771e7c231d17720b66" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz#8d007e3ef80b128a292be101201e75dec5480e5632e994771e7c231d17720b66" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.2
+++ b/plugins/python-build/share/python-build/3.4.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz#44a3c1ef1c7ca3e4fd25242af80ed72da941203cb4ed1a8c1b724d9078965dd8" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz#44a3c1ef1c7ca3e4fd25242af80ed72da941203cb4ed1a8c1b724d9078965dd8" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.3
+++ b/plugins/python-build/share/python-build/3.4.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz#4281ff86778db65892c05151d5de738d" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz#4281ff86778db65892c05151d5de738d" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.4
+++ b/plugins/python-build/share/python-build/3.4.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tgz#bc93e944025816ec360712b4c42d8d5f729eaed2b26585e9bc8844f93f0c382e" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tgz#bc93e944025816ec360712b4c42d8d5f729eaed2b26585e9bc8844f93f0c382e" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.5rc1
+++ b/plugins/python-build/share/python-build/3.4.5rc1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.5rc1" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5rc1.tgz#e060c18a260cdc9ec53a3089dd65422273efecc3932501cdc9a4e52fe2904d28" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "Python-3.4.5rc1" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5rc1.tgz#e060c18a260cdc9ec53a3089dd65422273efecc3932501cdc9a4e52fe2904d28" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.5-dev
+++ b/plugins/python-build/share/python-build/3.5-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-3.5-dev" "https://hg.python.org/cpython" "3.5" standard verify_py35 ensurepip verify_py35
+install_hg "Python-3.5-dev" "https://hg.python.org/cpython" "3.5" standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.0
+++ b/plugins/python-build/share/python-build/3.5.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" ldflags_dirs standard verify_py35 ensurepip verify_py35
+install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.1
+++ b/plugins/python-build/share/python-build/3.5.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" ldflags_dirs standard verify_py35 ensurepip verify_py35
+install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.2rc1
+++ b/plugins/python-build/share/python-build/3.5.2rc1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.5.2rc1" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2rc1.tgz#bcca0b50fcae6ea5a65cac7f1b7597c03261300c96808fd090f72067c5004b3b" ldflags_dirs standard verify_py35 ensurepip verify_py35
+install_package "Python-3.5.2rc1" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2rc1.tgz#bcca0b50fcae6ea5a65cac7f1b7597c03261300c96808fd090f72067c5004b3b" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-3.6-dev" "https://hg.python.org/cpython" "default" standard verify_py36 ensurepip verify_py36
+install_hg "Python-3.6-dev" "https://hg.python.org/cpython" "default" standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.0a1
+++ b/plugins/python-build/share/python-build/3.6.0a1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.6.0a1" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a1.tgz#16336eefaec9adf2e8e0035ddb622076f78e0c9c49db1d962f018bfb3804935e" ldflags_dirs standard verify_py36 ensurepip verify_py36
+install_package "Python-3.6.0a1" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a1.tgz#16336eefaec9adf2e8e0035ddb622076f78e0c9c49db1d962f018bfb3804935e" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.0a2
+++ b/plugins/python-build/share/python-build/3.6.0a2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.6.0a2" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a2.tgz#66600469e7938b6476e5caaa5a77eafe298877ad81896243970b724c1e6a0401" ldflags_dirs standard verify_py36 ensurepip verify_py36
+install_package "Python-3.6.0a2" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a2.tgz#66600469e7938b6476e5caaa5a77eafe298877ad81896243970b724c1e6a0401" ldflags_dirs standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/pypy-1.5
+++ b/plugins/python-build/share/python-build/pypy-1.5
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-c-jit-43780-b590cf6de419-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-linux.tar.bz2#a5a28457134a050bae59ee8d83cc65807bab10f0c7c3be547c6d9284f9a77989" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-c-jit-43780-b590cf6de419-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-linux.tar.bz2#a5a28457134a050bae59ee8d83cc65807bab10f0c7c3be547c6d9284f9a77989" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-c-jit-43780-b590cf6de419-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-linux64.tar.bz2#880b7f9288a6046aff62ded61a4f432ccb45038daee526356afa311d14c010a9" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-c-jit-43780-b590cf6de419-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-linux64.tar.bz2#880b7f9288a6046aff62ded61a4f432ccb45038daee526356afa311d14c010a9" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-c-jit-43780-b590cf6de419-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-osx64.tar.bz2#87294182aeacf2597c2bde358ffd6810295214db8cf81b07340598bb03ac44f0" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-c-jit-43780-b590cf6de419-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-osx64.tar.bz2#87294182aeacf2597c2bde358ffd6810295214db8cf81b07340598bb03ac44f0" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.5.0a0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-win32.zip#8ee727a9cfdc1957ced24a136a263279361efda73cc1354cc4877383565a4fe6" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-1.5.0a0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-win32.zip#8ee727a9cfdc1957ced24a136a263279361efda73cc1354cc4877383565a4fe6" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.5-src
+++ b/plugins/python-build/share/python-build/pypy-1.5-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-1.5-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-src.tar.bz2" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-1.5-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.5-src.tar.bz2" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-1.6
+++ b/plugins/python-build/share/python-build/pypy-1.6
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-linux.tar.bz2#1266c8b5918d84432b8649535fb5c84f6b977331c242bf45c5944033562ce0b2" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-linux.tar.bz2#1266c8b5918d84432b8649535fb5c84f6b977331c242bf45c5944033562ce0b2" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-linux64.tar.bz2#95b229c496339a51c4c1e9749bf8dbd11e4f698521803c089b52577be2cdbab8" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-linux64.tar.bz2#95b229c496339a51c4c1e9749bf8dbd11e4f698521803c089b52577be2cdbab8" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-osx64.tar.bz2#147a0e34b3d3a568d5c5926252a2c27e137677b3121cd8daab1d746df2d91e38" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-osx64.tar.bz2#147a0e34b3d3a568d5c5926252a2c27e137677b3121cd8daab1d746df2d91e38" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-win32-c.zip#75bf79f08e2d65fce51b14fb8fe0309f136ffc368f977017dc3029baf8426e53" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-1.6" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.6-win32-c.zip#75bf79f08e2d65fce51b14fb8fe0309f136ffc368f977017dc3029baf8426e53" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.7
+++ b/plugins/python-build/share/python-build/pypy-1.7
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-linux.tar.bz2#d8f6af52dd5c32ca65de8b1507ef49490188ec131d53a68db6f81201943b4227" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-linux.tar.bz2#d8f6af52dd5c32ca65de8b1507ef49490188ec131d53a68db6f81201943b4227" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-linux64.tar.bz2#cd7ff7a4beaaa78c3b9dbcd567fb0b2d672258051f837e727d4fd636788552ca" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-linux64.tar.bz2#cd7ff7a4beaaa78c3b9dbcd567fb0b2d672258051f837e727d4fd636788552ca" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-osx64.tar.bz2#9ad01f6e194b1a3d5f2fa82cd6760b4f9e8a791d5ca28cc156c5f03fe43a08ac" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-osx64.tar.bz2#9ad01f6e194b1a3d5f2fa82cd6760b4f9e8a791d5ca28cc156c5f03fe43a08ac" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-win32.zip#1d70faaed00f2f69c634dfbb61b54901df64f093d07d976e035578f812ed31ea" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-1.7" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.7-win32.zip#1d70faaed00f2f69c634dfbb61b54901df64f093d07d976e035578f812ed31ea" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.7-dev
+++ b/plugins/python-build/share/python-build/pypy-1.7-dev
@@ -1,2 +1,2 @@
 require_gcc
-install_hg "pypy-1.7-dev" "https://bitbucket.org/pypy/pypy" "release-1.7.x" "pypy_builder" verify_py27 ensurepip verify_py27
+install_hg "pypy-1.7-dev" "https://bitbucket.org/pypy/pypy" "release-1.7.x" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-1.8
+++ b/plugins/python-build/share/python-build/pypy-1.8
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-linux.tar.bz2#9c293d8540780260718f8fd8dc433c97b614a31b115ccfe2d68df720ad7e55b1" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-linux.tar.bz2#9c293d8540780260718f8fd8dc433c97b614a31b115ccfe2d68df720ad7e55b1" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-linux64.tar.bz2#1045606cceb993844a016b76c55aa43a9924bcf526f91a0572fc97cee69b61dc" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-linux64.tar.bz2#1045606cceb993844a016b76c55aa43a9924bcf526f91a0572fc97cee69b61dc" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-osx64.tar.bz2#b823b6b919082cfb67861b8253313b877618672377164086c0364fa8eaa88b8a" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-osx64.tar.bz2#b823b6b919082cfb67861b8253313b877618672377164086c0364fa8eaa88b8a" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-win32.zip#a844f54551805d300beffd10b18684e0c08fa080c1b6f7be52bb7fbdfdf38292" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-1.8" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.8-win32.zip#a844f54551805d300beffd10b18684e0c08fa080c1b6f7be52bb7fbdfdf38292" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.8-dev
+++ b/plugins/python-build/share/python-build/pypy-1.8-dev
@@ -1,2 +1,2 @@
 require_gcc
-install_hg "pypy-1.8-dev" "https://bitbucket.org/pypy/pypy" "release-1.8.x" "pypy_builder" verify_py27 ensurepip verify_py27
+install_hg "pypy-1.8-dev" "https://bitbucket.org/pypy/pypy" "release-1.8.x" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-1.9
+++ b/plugins/python-build/share/python-build/pypy-1.9
@@ -1,16 +1,16 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linux.tar.bz2#1e3f9c3d06f8bbfa0dcb1301b40c298096249a7d7c2b4594b3fb1c3e7b9888f2" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linux.tar.bz2#1e3f9c3d06f8bbfa0dcb1301b40c298096249a7d7c2b4594b3fb1c3e7b9888f2" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linux64.tar.bz2#4298252515e78c96f4ecd9f25be957411c060ece02d9213eef8d781cf528d18f" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-linux64.tar.bz2#4298252515e78c96f4ecd9f25be957411c060ece02d9213eef8d781cf528d18f" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-osx64.tar.bz2#4858f200e32c1070c77c1234ea0e9473eeda98bcd3832c4231f3e46e4e3b74b1" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-osx64.tar.bz2#4858f200e32c1070c77c1234ea0e9473eeda98bcd3832c4231f3e46e4e3b74b1" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-win32.zip#54fafe8c69df390d2a460bab022145aaacd2c62c4a569873b22fdc7475f31581" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-1.9" "https://bitbucket.org/pypy/pypy/downloads/pypy-1.9-win32.zip#54fafe8c69df390d2a460bab022145aaacd2c62c4a569873b22fdc7475f31581" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-1.9-dev
+++ b/plugins/python-build/share/python-build/pypy-1.9-dev
@@ -1,2 +1,2 @@
 require_gcc
-install_hg "pypy-1.9-dev" "https://bitbucket.org/pypy/pypy" "release-1.9.x" "pypy_builder" verify_py27 ensurepip verify_py27
+install_hg "pypy-1.9-dev" "https://bitbucket.org/pypy/pypy" "release-1.9.x" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0
+++ b/plugins/python-build/share/python-build/pypy-2.0
@@ -1,26 +1,26 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-linux.tar.bz2#275dbbee67eac527a1177403a0386b17d008740f83030544800d87994edd46b9" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-linux.tar.bz2#275dbbee67eac527a1177403a0386b17d008740f83030544800d87994edd46b9" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0-alpha-arm" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-alpha-arm-armel.tar.bz2#2f8f252d43a15661602a98f93d3292e333423459c5facb43eb2de1bda8eb8495" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0-alpha-arm" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-alpha-arm-armel.tar.bz2#2f8f252d43a15661602a98f93d3292e333423459c5facb43eb2de1bda8eb8495" "pypy" verify_py27 ensurepip
     ;;
 "linux-armhf" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0-alpha-arm" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-alpha-arm-armhf.tar.bz2#00e678e5a226be0692ee18438ace1c91d346256cfab8f32e34a24584d018ca34" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0-alpha-arm" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-alpha-arm-armhf.tar.bz2#00e678e5a226be0692ee18438ace1c91d346256cfab8f32e34a24584d018ca34" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-linux64.tar.bz2#14c716d53a507eece89606d547456b886dbdfc0ba6e3fb29062fafe86d1b6038" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-linux64.tar.bz2#14c716d53a507eece89606d547456b886dbdfc0ba6e3fb29062fafe86d1b6038" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-osx64.tar.bz2#6d190f32c9dce9d36d4a2bb91faed581a50fb7fa6249eee201dbf5dbc3e3c7d7" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-osx64.tar.bz2#6d190f32c9dce9d36d4a2bb91faed581a50fb7fa6249eee201dbf5dbc3e3c7d7" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-win32.zip#2f1d5a0d2cb2fa61902eba5479b100d6d26aab211149b06d5acf64089dd20fe1" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.0" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-win32.zip#2f1d5a0d2cb2fa61902eba5479b100d6d26aab211149b06d5acf64089dd20fe1" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0-dev
+++ b/plugins/python-build/share/python-build/pypy-2.0-dev
@@ -1,2 +1,2 @@
 require_gcc
-install_hg "pypy-2.0-dev" "https://bitbucket.org/pypy/pypy" "release-2.0.x" "pypy_builder" verify_py27 ensurepip verify_py27
+install_hg "pypy-2.0-dev" "https://bitbucket.org/pypy/pypy" "release-2.0.x" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0-src.tar.bz2#d92dfd418beac915d3efc28f8a2090f3c13a89ec653419deff3d7112c5c111f3" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.1
+++ b/plugins/python-build/share/python-build/pypy-2.0.1
@@ -1,18 +1,18 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-linux.tar.bz2#548686c5b95b424c79586d9a303ed41fca8eba52bd35c1527f39f5cd8fa35ea9" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-linux.tar.bz2#548686c5b95b424c79586d9a303ed41fca8eba52bd35c1527f39f5cd8fa35ea9" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-linux64.tar.bz2#0eb57e28f2bd5f2a4ad396df322de5adf711eb7d9a2bfeb8be2d9eb9e125c5cc" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-linux64.tar.bz2#0eb57e28f2bd5f2a4ad396df322de5adf711eb7d9a2bfeb8be2d9eb9e125c5cc" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-osx64.tar.bz2#337f2fda672827f2d706fd98e3344a83a8b80675e21b83dd6933da38d110c857" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-osx64.tar.bz2#337f2fda672827f2d706fd98e3344a83a8b80675e21b83dd6933da38d110c857" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-win32.zip#78fff168c10176a3a7f6a5b97d2048ed87f3cd9a6284b5afa86115baa19af946" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.0.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-win32.zip#78fff168c10176a3a7f6a5b97d2048ed87f3cd9a6284b5afa86115baa19af946" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.1-src.tar.bz2#d1327bc325545939236ac609ec509548a545f97b1c933dedbe42f2482a130aa0" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.0.2
+++ b/plugins/python-build/share/python-build/pypy-2.0.2
@@ -1,18 +1,18 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux.tar.bz2#3b43c1ac147f6bb11981dd7f8c5458b95d6bdcf1adceb8043c32ca5e8fcab4da" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux.tar.bz2#3b43c1ac147f6bb11981dd7f8c5458b95d6bdcf1adceb8043c32ca5e8fcab4da" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux64.tar.bz2#3f9bc07959a2d6058a0c1b84da837e2ec457642fe03ac46123d145c419a7b5cd" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-linux64.tar.bz2#3f9bc07959a2d6058a0c1b84da837e2ec457642fe03ac46123d145c419a7b5cd" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-osx64.tar.bz2#34f5a7bf22a8bca3b9d79ae3186016c34638669ab19b4af6e38412181c757761" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-osx64.tar.bz2#34f5a7bf22a8bca3b9d79ae3186016c34638669ab19b4af6e38412181c757761" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-win32.zip#f3cfa54740076c59e6ef02e1411f62551230df5cd20a247e81b6e589478afe66" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.0.2" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-win32.zip#f3cfa54740076c59e6ef02e1411f62551230df5cd20a247e81b6e589478afe66" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.0.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.0.2-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.0.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.0.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.0.2-src.tar.bz2#1991c90d6b98e2408b3790d4b57b71ec1c69346328b8321505ce8f6ab4544c3c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.1
+++ b/plugins/python-build/share/python-build/pypy-2.1
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux.tar.bz2#9c0a38a40d3b4e642a159e51abef2827b33e3f7a254365daa24eae85d840eaf5" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux.tar.bz2#9c0a38a40d3b4e642a159e51abef2827b33e3f7a254365daa24eae85d840eaf5" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armel.tar.bz2#15af2d7485c9e4363805ad5b63bf8a67cd9516e7e34c4abb822229a2a41aee1d" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armel.tar.bz2#15af2d7485c9e4363805ad5b63bf8a67cd9516e7e34c4abb822229a2a41aee1d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armhf-raspbian.tar.bz2#b11c27447051af00928fcc3d1f20f1441c285045a3acb8cfba8721c63ee90df3" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armhf-raspbian.tar.bz2#b11c27447051af00928fcc3d1f20f1441c285045a3acb8cfba8721c63ee90df3" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armhf-raring.tar.bz2#fbab31154848f309ef72b6e845e289285907eda950f6b632963217c463b5d4de" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux-armhf-raring.tar.bz2#fbab31154848f309ef72b6e845e289285907eda950f6b632963217c463b5d4de" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux64.tar.bz2#80f90bb473635a0249049e87c5cc7cf738e13537c1f1e2857b6345848a3e6d20" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-linux64.tar.bz2#80f90bb473635a0249049e87c5cc7cf738e13537c1f1e2857b6345848a3e6d20" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-osx64.tar.bz2#d0d788c6d54bb866ace67a1740133cb5bc62357b5ca4783244097f1f648876f0" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-osx64.tar.bz2#d0d788c6d54bb866ace67a1740133cb5bc62357b5ca4783244097f1f648876f0" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-win32.zip#c425a35a6c4938e314ad48014816e05c8e5246d770abe135e11a1f9821eecf53" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.1" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-win32.zip#c425a35a6c4938e314ad48014816e05c8e5246d770abe135e11a1f9821eecf53" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.1-src.tar.bz2#31b3066c9739b117d6bb1bdc485a919dc3b67370ec00437de1b74069943f7f17" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2
+++ b/plugins/python-build/share/python-build/pypy-2.2
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.2-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux.tar.bz2#2bdab70106f6b6d0dd97e42535ce73711c987887fb81fb821801f6fdcd92cdc4" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux.tar.bz2#2bdab70106f6b6d0dd97e42535ce73711c987887fb81fb821801f6fdcd92cdc4" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armel.tar.bz2#98bfc524f9cf4fd96225f9fc9b0a3a379b8a1a06231b058c51bb875b363f4d75" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armel.tar.bz2#98bfc524f9cf4fd96225f9fc9b0a3a379b8a1a06231b058c51bb875b363f4d75" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.2-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armhf-raspbian.tar.bz2#4856151d9a6dda82edd9d74f872e97243df3676fc25bbf661f976982194caa47" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.2-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armhf-raspbian.tar.bz2#4856151d9a6dda82edd9d74f872e97243df3676fc25bbf661f976982194caa47" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.2-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armhf-raring.tar.bz2#d64eeeac0a73bd073d8f875210b0e85ed8f0d9655d3f3cc8abb68093a1eb7366" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.2-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux-armhf-raring.tar.bz2#d64eeeac0a73bd073d8f875210b0e85ed8f0d9655d3f3cc8abb68093a1eb7366" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux64.tar.bz2#1583af0122c6ccb0cb95f8c3732925551ce3ca6d5ea0657e21523f8bf97837a3" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-linux64.tar.bz2#1583af0122c6ccb0cb95f8c3732925551ce3ca6d5ea0657e21523f8bf97837a3" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.2-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-osx64.tar.bz2#8aa943de7ec38f13fa836b6964dbf58b45142e4fe7b3fdd5fffe37fdcf974e01" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-osx64.tar.bz2#8aa943de7ec38f13fa836b6964dbf58b45142e4fe7b3fdd5fffe37fdcf974e01" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.2-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-win32.zip#c7a6682cde9034835b337be95415aee21cb4de85049d65a4674efe15d214dfb9" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.2-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-win32.zip#c7a6682cde9034835b337be95415aee21cb4de85049d65a4674efe15d214dfb9" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.2-src
+++ b/plugins/python-build/share/python-build/pypy-2.2-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.2-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2-src.tar.bz2#50fffcb86039e019530a63d656580bc53c173e5f19768bddd8699cd08448e04e" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.2.1
+++ b/plugins/python-build/share/python-build/pypy-2.2.1
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.2.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux.tar.bz2#4d13483a0e13fc617a7b3d36918ed0e63cf07a7d2827c0a08132b80bc401a55a" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux.tar.bz2#4d13483a0e13fc617a7b3d36918ed0e63cf07a7d2827c0a08132b80bc401a55a" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armel.tar.bz2#f0a15c7f4d66f152c58d73475314b906dcd3052fc422a8bb8cf88ae1ca0a8b19" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armel.tar.bz2#f0a15c7f4d66f152c58d73475314b906dcd3052fc422a8bb8cf88ae1ca0a8b19" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.2.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armhf-raspbian.tar.bz2#31d921a8139ec6accf9749df2baff4aed844f6f46eeb37184119ff9c7d6fca55" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.2.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armhf-raspbian.tar.bz2#31d921a8139ec6accf9749df2baff4aed844f6f46eeb37184119ff9c7d6fca55" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.2.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armhf-raring.tar.bz2#6f5fe3285a32d1ea8fe148265467f870c6863ae00bc2e279b31b94d2d7f80102" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.2.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux-armhf-raring.tar.bz2#6f5fe3285a32d1ea8fe148265467f870c6863ae00bc2e279b31b94d2d7f80102" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.2.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux64.tar.bz2#022d611ac62a276890d3e262f4f7cc839fcf9f5e1416df01dcd83ba335eacb16" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-linux64.tar.bz2#022d611ac62a276890d3e262f4f7cc839fcf9f5e1416df01dcd83ba335eacb16" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.2.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-osx64.tar.bz2#93e215dcffc9073acf41c63518f47fb59de60386aca4416cfe32190c7a096f29" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.2.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-osx64.tar.bz2#93e215dcffc9073acf41c63518f47fb59de60386aca4416cfe32190c7a096f29" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.2.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-win32.zip#d36f4f1b4f146b3a0a623abef9b5a837c08f66e67c90023c724dfdcd8e0133bb" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.2.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-win32.zip#d36f4f1b4f146b3a0a623abef9b5a837c08f66e67c90023c724dfdcd8e0133bb" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.2.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.2.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.2.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.2.1-src.tar.bz2#252045187e443656a2beb412dadac9296e8fe8db0f75a66ed5265db58c35035f" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3
+++ b/plugins/python-build/share/python-build/pypy-2.3
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.3-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux.tar.bz2#9071072d42344fb37cc588429864b00fff447bd5d33d51008641fe6822823f1b" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux.tar.bz2#9071072d42344fb37cc588429864b00fff447bd5d33d51008641fe6822823f1b" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.3-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armel.tar.bz2#18394acc9ce356d109cbd92224a9d724a7eb53a0505ce0ec5de36ee20b288a07" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armel.tar.bz2#18394acc9ce356d109cbd92224a9d724a7eb53a0505ce0ec5de36ee20b288a07" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.3-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armhf-raspbian.tar.bz2#92584cfccde188b6a3a850ecf226daa9924788a1da8574c57c10a7551fb127d4" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armhf-raspbian.tar.bz2#92584cfccde188b6a3a850ecf226daa9924788a1da8574c57c10a7551fb127d4" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.3-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armhf-raring.tar.bz2#c8c4a4da406db8ea6dfec074951e1ac150619b0709317ceaafb6bdd837acf96e" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux-armhf-raring.tar.bz2#c8c4a4da406db8ea6dfec074951e1ac150619b0709317ceaafb6bdd837acf96e" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.3-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux64.tar.bz2#777dbdd9c67ad1b8906288b01ae76bc9f7b80c95e967836f9a700a1679b80008" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-linux64.tar.bz2#777dbdd9c67ad1b8906288b01ae76bc9f7b80c95e967836f9a700a1679b80008" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.3-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-osx64.tar.bz2#df7ca23ba6c8a63149d910b482be04f069b26dd1f7d0ca15e6342cac94e759d7" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-osx64.tar.bz2#df7ca23ba6c8a63149d910b482be04f069b26dd1f7d0ca15e6342cac94e759d7" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.3-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-win32.zip#72f46afe69281147ad9abc88a7b39d1840e112e626a8be251a5f9f7308c559c7" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.3-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-win32.zip#72f46afe69281147ad9abc88a7b39d1840e112e626a8be251a5f9f7308c559c7" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.3-src
+++ b/plugins/python-build/share/python-build/pypy-2.3-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-394146e9bb67" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-pypy-394146e9bb67" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3-src.tar.bz2#be2c271e7f9d7c0059a551ba1501713c00336e551e7f13107f0f34c721d95b0c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.3.1
+++ b/plugins/python-build/share/python-build/pypy-2.3.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux.tar.bz2#3eed698e8533cca7cbd2c2c87fce39dc14baa7dec03f4b082d870131d2a470e4" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armel.tar.bz2#4d71679597b4e971d7e566d9696851dd2ec1a90a04696184d2d0f6b5446d9706" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armel.tar.bz2#4d71679597b4e971d7e566d9696851dd2ec1a90a04696184d2d0f6b5446d9706" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armhf-raspbian.tar.bz2#74ac62f8cf6dfa0b2f04debd8bbedaed21a12a1a4d4da22856410d06dc0c971c" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armhf-raspbian.tar.bz2#74ac62f8cf6dfa0b2f04debd8bbedaed21a12a1a4d4da22856410d06dc0c971c" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armhf-raring.tar.bz2#f65ad31c364e8122f55d77388026cf4750c6a8774af361b79dc9942612c3a8c1" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux-armhf-raring.tar.bz2#f65ad31c364e8122f55d77388026cf4750c6a8774af361b79dc9942612c3a8c1" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-linux64.tar.bz2#dab7940496d96f1f255a8ef402fa96b94444775e373484e057d2fcabc3928b42" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-osx64.tar.bz2#12e363bf5ea3a508600e043b68c47d4148359ca3d999ee207665bb139f8fbf37" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-osx64.tar.bz2#12e363bf5ea3a508600e043b68c47d4148359ca3d999ee207665bb139f8fbf37" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-win32.zip#c8db46d0e5199420dae583f6d2901eb4d4023ced75f035a6e26c232f229f8e0a" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.3.1-win32.zip#c8db46d0e5199420dae583f6d2901eb4d4023ced75f035a6e26c232f229f8e0a" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.3.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-32f35069a16d" "https://bitbucket.org/pypy/pypy/get/release-2.3.1.tar.bz2#3fd10d97c0177c33ed358a78eb26f5bf1f91b266af853564b1a9d8c310a1e439" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-pypy-32f35069a16d" "https://bitbucket.org/pypy/pypy/get/release-2.3.1.tar.bz2#3fd10d97c0177c33ed358a78eb26f5bf1f91b266af853564b1a9d8c310a1e439" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.4-beta1
+++ b/plugins/python-build/share/python-build/pypy-2.4-beta1
@@ -1,30 +1,30 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   require_distro "Ubuntu 10.04" || true
-  install_package "pypy-2.4-beta1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux.tar.bz2#8b63af8791ed7b5316b746af7c9a38f52e92f8153b4e97343778d01b0893ea6d" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4-beta1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux.tar.bz2#8b63af8791ed7b5316b746af7c9a38f52e92f8153b4e97343778d01b0893ea6d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.4-beta1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux-armel.tar.bz2#429c6439f2492ab5541d95673cc71fd3f6e76f4c9695a047f3d23c25de33c849" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4-beta1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux-armel.tar.bz2#429c6439f2492ab5541d95673cc71fd3f6e76f4c9695a047f3d23c25de33c849" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.4-beta1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux-armhf-raspbian.tar.bz2#b6f4b253cfbeb4fb6e842ab29d432edefcd6c5f78b6505139d19c84dd4a2839a" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4-beta1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux-armhf-raspbian.tar.bz2#b6f4b253cfbeb4fb6e842ab29d432edefcd6c5f78b6505139d19c84dd4a2839a" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.4-beta1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux-armhf-raring.tar.bz2#ecc35b8ef369e3a1686b50de8574cee0b1971d9510a329d7e34851b71d774a71" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4-beta1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux-armhf-raring.tar.bz2#ecc35b8ef369e3a1686b50de8574cee0b1971d9510a329d7e34851b71d774a71" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.4-beta1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux64.tar.bz2#b526aa67c2fa84fbda7e36354648369573d4efc4e95b948210f79dc3b3330869" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4-beta1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-linux64.tar.bz2#b526aa67c2fa84fbda7e36354648369573d4efc4e95b948210f79dc3b3330869" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_package "pypy-2.4-beta1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-osx64.tar.bz2#aec6dc3eb1014940ade3b1ff77edb67a1b95e94cee6e9e49ac15b7edeffe92e1" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4-beta1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-osx64.tar.bz2#aec6dc3eb1014940ade3b1ff77edb67a1b95e94cee6e9e49ac15b7edeffe92e1" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.4-beta1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-win32.zip#763952626ffdad105d336b3a28f538c65263502eb08a9c37f073873693f75c32" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.4-beta1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4-beta1-win32.zip#763952626ffdad105d336b3a28f538c65263502eb08a9c37f073873693f75c32" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.4-beta1-src
+++ b/plugins/python-build/share/python-build/pypy-2.4-beta1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-9f425c60afdf" "https://bitbucket.org/pypy/pypy/get/release-2.4-beta1.tar.bz2#4baa5663872cf47e18fb35232cc70503b087e0d3f927bd4cc4bbf7ef578b13bd" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-pypy-9f425c60afdf" "https://bitbucket.org/pypy/pypy/get/release-2.4-beta1.tar.bz2#4baa5663872cf47e18fb35232cc70503b087e0d3f927bd4cc4bbf7ef578b13bd" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.4.0
+++ b/plugins/python-build/share/python-build/pypy-2.4.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux.tar.bz2#a24adb366f87ac0eba829d7188a156a7d897e71893689fab06502c3f4152ac0e" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armel.tar.bz2#8362d634bf86fbfb3b99b578b13c0a9fd673b2b7580d6d65b4a181934c659ccd" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armel.tar.bz2#8362d634bf86fbfb3b99b578b13c0a9fd673b2b7580d6d65b4a181934c659ccd" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armhf-raspbian.tar.bz2#5e0ba69b28ffbd5b61b0b6be2a130ab0c80e7d2da289d9530b0b6eac4302d5fa" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armhf-raspbian.tar.bz2#5e0ba69b28ffbd5b61b0b6be2a130ab0c80e7d2da289d9530b0b6eac4302d5fa" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armhf-raring.tar.bz2#ddbdd6207c41cf82d8c96d52a2a204a2cdada9301cb577f9b323f22394bb1f0a" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux-armhf-raring.tar.bz2#ddbdd6207c41cf82d8c96d52a2a204a2cdada9301cb577f9b323f22394bb1f0a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-linux64.tar.bz2#27cdc0d6e8bce2637678f6d076fc780877dffe1bf9aec9e253f95219af9ed099" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-osx64.tar.bz2#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-osx64.tar.bz2#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-win32.zip#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.4.0-win32.zip#3eb8afdfa42bc9b08b4d3058e21d4ce978a52722fdcfdc67d6c3ee5013a51aaa" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.4.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-c6ad44ecf5d8" "https://bitbucket.org/pypy/pypy/get/release-2.4.0.tar.bz2#7e0dec2c40106f20f002121bdabb71939915254fb91bd55b01434e4b994113d2" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-pypy-c6ad44ecf5d8" "https://bitbucket.org/pypy/pypy/get/release-2.4.0.tar.bz2#7e0dec2c40106f20f002121bdabb71939915254fb91bd55b01434e4b994113d2" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.0
+++ b/plugins/python-build/share/python-build/pypy-2.5.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux.tar.bz2#3dfd56a986d25929b4ed9f40a5484f72f1d513cd816cf8aaa683106c3391247c" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.5.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armel.tar.bz2#277fa6c61d63af96893dafd19e1ffea7b988397c6a0fd66cd99dc0db1029be56" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armel.tar.bz2#277fa6c61d63af96893dafd19e1ffea7b988397c6a0fd66cd99dc0db1029be56" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.5.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armhf-raspbian.tar.bz2#6c975e39f0e7d57176b49a987a08862a3cbd9aeb52f47eb4ab148ea334e747fd" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armhf-raspbian.tar.bz2#6c975e39f0e7d57176b49a987a08862a3cbd9aeb52f47eb4ab148ea334e747fd" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.5.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armhf-raring.tar.bz2#1866bf2b8a8144c68d64f2ba982c6c545849913167b4602b762716332ec1fa0b" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux-armhf-raring.tar.bz2#1866bf2b8a8144c68d64f2ba982c6c545849913167b4602b762716332ec1fa0b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-linux64.tar.bz2#7764fb6b662407f8709eaa334c542aac9cb6bfe3291ac198dad0980ca129f3c2" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.5.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-osx64.tar.bz2#30b392b969b54cde281b07f5c10865a7f2e11a229c46b8af384ca1d3fe8d4e6e" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-osx64.tar.bz2#30b392b969b54cde281b07f5c10865a7f2e11a229c46b8af384ca1d3fe8d4e6e" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.5.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-win32.zip#692391434cf14016d74c6b8bda8f93135ef026f48c8327f3195bfa24d314317d" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.5.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.0-win32.zip#692391434cf14016d74c6b8bda8f93135ef026f48c8327f3195bfa24d314317d" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.5.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-pypy-10f1b29a2bd2" "https://bitbucket.org/pypy/pypy/get/release-2.5.0.tar.bz2#8d644a55a3150cf3d18536c784e3410bb3f3438c1505000c4f761863bacedf88" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-pypy-10f1b29a2bd2" "https://bitbucket.org/pypy/pypy/get/release-2.5.0.tar.bz2#8d644a55a3150cf3d18536c784e3410bb3f3438c1505000c4f761863bacedf88" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-2.5.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux.tar.bz2#c0035a2650cafcb384050a8c476ddc41c9fd40b0c3677fab68026f57c715907a" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.5.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armel.tar.bz2#91d68551b6e738c1e47aaed869a6df8208abb8c60194a1647c6aa13c7363a61d" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armel.tar.bz2#91d68551b6e738c1e47aaed869a6df8208abb8c60194a1647c6aa13c7363a61d" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.5.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armhf-raspbian.tar.bz2#2b730f86b56fcc72f5bfcfe6a38b5a6fe27654f73b2256e10297373af169a69e" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armhf-raspbian.tar.bz2#2b730f86b56fcc72f5bfcfe6a38b5a6fe27654f73b2256e10297373af169a69e" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.5.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armhf-raring.tar.bz2#0a5648c18cc604b0a8eaa559549cb332d18358fc551865e9b7ef051b796e4ec7" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux-armhf-raring.tar.bz2#0a5648c18cc604b0a8eaa559549cb332d18358fc551865e9b7ef051b796e4ec7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-linux64.tar.bz2#68e0955dbc80a0d51dfa9a8a76d8623f34920ece1bcbc6d910c2be019a653ba8" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.5.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-osx64.tar.bz2#db40dc8b5e95ef9c3322bd9897099e91555ef34188cf1c3852a92b081142d183" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-osx64.tar.bz2#db40dc8b5e95ef9c3322bd9897099e91555ef34188cf1c3852a92b081142d183" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.5.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-win32.zip#0dbf90c30e848a91611bea99968a215244db02cf5f649114f10269cf1a15d607" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.5.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-win32.zip#0dbf90c30e848a91611bea99968a215244db02cf5f649114f10269cf1a15d607" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.5.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.5.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.5.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.5.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.5.1-src.tar.bz2#ddb3a580b1ee99c5a699172d74be91c36dda9a38946d4731d8c6a63120a3ba2a" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.0
+++ b/plugins/python-build/share/python-build/pypy-2.6.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux.tar.bz2#6e0b052c40a59bf5a85ee239980bbcab8b031b4c2bc33b99efe1b072977d9910" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.6.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armel.tar.bz2#9d0cb9b15283f9c15f83c05293f8bd41d302c96090fd89b778f359df9bc8e619" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armel.tar.bz2#9d0cb9b15283f9c15f83c05293f8bd41d302c96090fd89b778f359df9bc8e619" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.6.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armhf-raspbian.tar.bz2#e9f6a16c3e21f38bd571adb33757649ceef3f2ebfdd6d37eea923ce26ea6728c" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armhf-raspbian.tar.bz2#e9f6a16c3e21f38bd571adb33757649ceef3f2ebfdd6d37eea923ce26ea6728c" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.6.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armhf-raring.tar.bz2#ccb37a6d861b6dd69cd038337664885dcf91852a2ab6aef480dd7cfbda8de502" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux-armhf-raring.tar.bz2#ccb37a6d861b6dd69cd038337664885dcf91852a2ab6aef480dd7cfbda8de502" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-linux64.tar.bz2#f5d2b0e3594cec57e32d3e43a951041ec330e1e962a836be470d591633e51388" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.6.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-osx64.tar.bz2#77f1d056484e40e0a8e2e2b2b489eedfe785605ef36b144ffce05f7b748f6acd" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-osx64.tar.bz2#77f1d056484e40e0a8e2e2b2b489eedfe785605ef36b144ffce05f7b748f6acd" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.6.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-win32.zip#de907e7fef7b9b6ceccfc8aa5f4781ee3bc4a49b119d4b22ab5e25eab21c6e8d" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.6.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-win32.zip#de907e7fef7b9b6ceccfc8aa5f4781ee3bc4a49b119d4b22ab5e25eab21c6e8d" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.6.0-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.0-src.tar.bz2#9bf353f22d25e97a85a6d3766619966055edea1ea1b2218445d683a8ad0399d9" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-2.6.1
+++ b/plugins/python-build/share/python-build/pypy-2.6.1
@@ -1,39 +1,39 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "freebsd64" )
-  install_package "pypy-2.6.1-freebsd64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-freebsd64.tar.bz2#58118e88ce01c1d48b31d293db40687efbdeba54334eb55ba96de9ecf3c39055" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.1-freebsd64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-freebsd64.tar.bz2#58118e88ce01c1d48b31d293db40687efbdeba54334eb55ba96de9ecf3c39055" "pypy" verify_py27 ensurepip
   ;;
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux.tar.bz2#d010b1f1aafdb01beb107f16843985508ce81698260ce830690686d9b2768c88" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-2.6.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armel.tar.bz2#0ca15d289e78a82f927b375a016b7c3246accac5d7eebded4e32a496fb3245ab" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armel.tar.bz2#0ca15d289e78a82f927b375a016b7c3246accac5d7eebded4e32a496fb3245ab" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-2.6.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armhf-raspbian.tar.bz2#13d983805ebc6d9a3627dea3c34898375a4e4e7b6f0171cfbde463c1c04a92aa" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armhf-raspbian.tar.bz2#13d983805ebc6d9a3627dea3c34898375a4e4e7b6f0171cfbde463c1c04a92aa" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-2.6.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armhf-raring.tar.bz2#4caa7c1922a212cca4690bfa181cd368760a23b50163b3cbbd6d28401dd5cef5" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux-armhf-raring.tar.bz2#4caa7c1922a212cca4690bfa181cd368760a23b50163b3cbbd6d28401dd5cef5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-2.6.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-linux64.tar.bz2#78a48490d1b2dba8571156c2bf822324ca7dae6f6a56a4bbb96d3e8e8885367b" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-2.6.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-osx64.tar.bz2#4a78ef76ec38a49a9de40225c337e89486fa09938c600df2bd2dd60110066f65" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-osx64.tar.bz2#4a78ef76ec38a49a9de40225c337e89486fa09938c600df2bd2dd60110066f65" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-2.6.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-win32.zip#ccea3940fdedc03e2fcb5acf6badfe6d9c1ae876d5faf0a004e1d94edd7fd856" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-2.6.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-win32.zip#ccea3940fdedc03e2fcb5acf6badfe6d9c1ae876d5faf0a004e1d94edd7fd856" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-2.6.1-src
+++ b/plugins/python-build/share/python-build/pypy-2.6.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-2.6.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-2.6.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-2.6.1-src.tar.bz2#7fddd414c9348c2f899f79ad86adc3fc2b19443855b5243f58487e1f0ac46560" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.0
+++ b/plugins/python-build/share/python-build/pypy-4.0.0
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux.tar.bz2#365600947775bc73a902a5b1d11f8b96cf49f07cdbbab28bb47240097b4bb4c5" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-4.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-4.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armel.tar.bz2#612df41fa21c5bc95d8d3575e0d8c09f605de6f0684109222afa561672dd9c7b" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armel.tar.bz2#612df41fa21c5bc95d8d3575e0d8c09f605de6f0684109222afa561672dd9c7b" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-4.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armhf-raspbian.tar.bz2#fccd9d8436781cbeb8c94e2b37e590303c52e63bc50ed30c4a99a46f022c44bb" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armhf-raspbian.tar.bz2#fccd9d8436781cbeb8c94e2b37e590303c52e63bc50ed30c4a99a46f022c44bb" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-4.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armhf-raring.tar.bz2#9586d9accdb8faa488a313132047e0dad73c8facc222201380d4935a2ba429b8" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux-armhf-raring.tar.bz2#9586d9accdb8faa488a313132047e0dad73c8facc222201380d4935a2ba429b8" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
   require_distro "Fedora 20" || true
-  install_package "pypy-4.0.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-ppc64.tar.bz2#729eab7fa84289a094d69fe1607ef97c8e7acc08588db5cd410c9dd26bdd4110" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-ppc64.tar.bz2#729eab7fa84289a094d69fe1607ef97c8e7acc08588db5cd410c9dd26bdd4110" "pypy" verify_py27 ensurepip
   ;;
 "linux-ppc64le" )
   require_distro "Fedora 21" || true
-  install_package "pypy-4.0.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-ppc64le.tar.bz2#0ba3c313afb48cba2798c9b46e9a27e24a597f90e092b649b6ac9cd8af4f7765" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-ppc64le.tar.bz2#0ba3c313afb48cba2798c9b46e9a27e24a597f90e092b649b6ac9cd8af4f7765" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux64.tar.bz2#30365cf4fa6cd8e9ff44126f06dcaebefda35c2543ddcf9b9e8516c29cabe726" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-linux64.tar.bz2#30365cf4fa6cd8e9ff44126f06dcaebefda35c2543ddcf9b9e8516c29cabe726" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-4.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_x86_64-portable.tar.bz2#61fb04eaa823763b8de777e16edc02b09116985586f53c14c6e85d531072a38f" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_x86_64-portable.tar.bz2#61fb04eaa823763b8de777e16edc02b09116985586f53c14c6e85d531072a38f" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-4.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-osx64.tar.bz2#d9e590fe5b9461bbdff56c76636e844ef90a297f82d0d2e204866c8a21759a50" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-osx64.tar.bz2#d9e590fe5b9461bbdff56c76636e844ef90a297f82d0d2e204866c8a21759a50" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-4.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-win32.zip#d906ffa98b120496cbbc1623d0fd08662c3a589340ae7071c669432eccf26e00" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-4.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-win32.zip#d906ffa98b120496cbbc1623d0fd08662c3a589340ae7071c669432eccf26e00" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-4.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-4.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-4.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.0-src.tar.bz2#acff480e44ce92acd057f2e786775af36dc3c2cd12e9efc60a1ac6a562ad7b4d" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-4.0.1
+++ b/plugins/python-build/share/python-build/pypy-4.0.1
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux.tar.bz2#721920fcbb6aefc9a98e868e32b7f4ea5fd68b7f9305d08d0a2595327c9c0611" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-4.0.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armel.tar.bz2#d1acdd45ebd34580dd632c63c95211f6bae5e9a8f7a46ffa6f0443286ff9f61b" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armel.tar.bz2#d1acdd45ebd34580dd632c63c95211f6bae5e9a8f7a46ffa6f0443286ff9f61b" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-4.0.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armhf-raspbian.tar.bz2#52eef495f560af59a787b9935367cb5f8c83b48e32a80ec3e7060bffac011ecc" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armhf-raspbian.tar.bz2#52eef495f560af59a787b9935367cb5f8c83b48e32a80ec3e7060bffac011ecc" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-4.0.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armhf-raring.tar.bz2#e67278ce7423aa7bf99a95fd271cb76763eae3106930f4b7de1fba6a70a3f383" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux-armhf-raring.tar.bz2#e67278ce7423aa7bf99a95fd271cb76763eae3106930f4b7de1fba6a70a3f383" "pypy" verify_py27 ensurepip
   fi
   ;;
 #"linux-ppc64" )
 #  require_distro "Fedora 20" || true
-#  install_package "pypy-4.0.1-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-ppc64.tar.bz2#2aadbb7638153b9d7c2a832888ed3c1e" "pypy" verify_py27 ensurepip verify_py27
+#  install_package "pypy-4.0.1-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-ppc64.tar.bz2#2aadbb7638153b9d7c2a832888ed3c1e" "pypy" verify_py27 ensurepip
 #  ;;
 #"linux-ppc64le" )
 #  require_distro "Fedora 21" || true
-#  install_package "pypy-4.0.1-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-ppc64le.tar.bz2#d4492e65201bb09dca5f97601113dc57" "pypy" verify_py27 ensurepip verify_py27
+#  install_package "pypy-4.0.1-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-ppc64le.tar.bz2#d4492e65201bb09dca5f97601113dc57" "pypy" verify_py27 ensurepip
 #  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-4.0.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux64.tar.bz2#0d6090cee59f4b9bab91ddbea76580d0c232b78dae65aaa9e8fa8d4449ba25b4" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-linux64.tar.bz2#0d6090cee59f4b9bab91ddbea76580d0c232b78dae65aaa9e8fa8d4449ba25b4" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-4.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_x86_64-portable.tar.bz2#b3803f6dd9bbb964f7d322aa4aeb93191ff0ebe573428c1d2014ea26da49ff53" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-4.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_x86_64-portable.tar.bz2#b3803f6dd9bbb964f7d322aa4aeb93191ff0ebe573428c1d2014ea26da49ff53" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-4.0.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-osx64.tar.bz2#06be1299691f7ea558bf8e3bdf3d20debb8ba03cd7cadf04f2d6cbd5fd084430" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-osx64.tar.bz2#06be1299691f7ea558bf8e3bdf3d20debb8ba03cd7cadf04f2d6cbd5fd084430" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-4.0.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-win32.zip#9a350a5e6f9b86fb525c6f1300b0c97c021ea8b1e37bfd32a8c4bb7a415d5329" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-4.0.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-win32.zip#9a350a5e6f9b86fb525c6f1300b0c97c021ea8b1e37bfd32a8c4bb7a415d5329" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-4.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-4.0.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-4.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-4.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-4.0.1-src.tar.bz2#29f5aa6ba17b34fd980e85172dfeb4086fdc373ad392b1feff2677d2d8aea23c" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.0
+++ b/plugins/python-build/share/python-build/pypy-5.0.0
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux.tar.bz2#a9cc9afa94ff1cde811626a70081c477c9840e7816c0562d1903fd823d222ceb" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armel.tar.bz2#87bd85441b16ecca0d45ba6e9c0e9d26bb7bd8867afbf79d80312cf79b032dc1" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armel.tar.bz2#87bd85441b16ecca0d45ba6e9c0e9d26bb7bd8867afbf79d80312cf79b032dc1" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armhf-raspbian.tar.bz2#8033c0cc39e9f6771688f2eda95c726595f5453b3e73e1cd5f7ebbe3dae1f685" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armhf-raspbian.tar.bz2#8033c0cc39e9f6771688f2eda95c726595f5453b3e73e1cd5f7ebbe3dae1f685" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armhf-raring.tar.bz2#5bb52cf5db4ae8497c4e03cd8a70e49867e6b93d9f29ad335d030fcd3a375769" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux-armhf-raring.tar.bz2#5bb52cf5db4ae8497c4e03cd8a70e49867e6b93d9f29ad335d030fcd3a375769" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
  require_distro "Fedora 20" || true
- install_package "pypy-5.0.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-ppc64.tar.bz2#334a37e68cb543cf2cbcdd12379b9b770064bb70ba7fd104f1e451cfa10cdda5" "pypy" verify_py27 ensurepip verify_py27
+ install_package "pypy-5.0.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-ppc64.tar.bz2#334a37e68cb543cf2cbcdd12379b9b770064bb70ba7fd104f1e451cfa10cdda5" "pypy" verify_py27 ensurepip
  ;;
 "linux-ppc64le" )
  require_distro "Fedora 21" || true
- install_package "pypy-5.0.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-ppc64le.tar.bz2#e72fe5c094186f79c997000ddbaa01616def652a8d1338b75a27dfa3755eb86c" "pypy" verify_py27 ensurepip verify_py27
+ install_package "pypy-5.0.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-ppc64le.tar.bz2#e72fe5c094186f79c997000ddbaa01616def652a8d1338b75a27dfa3755eb86c" "pypy" verify_py27 ensurepip
  ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-linux64.tar.bz2#b9c73be8e3c3b0835df83bdb86335712005240071cdd4dc245ac30b457063ae0" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-osx64.tar.bz2#45ed8bf799d0fd8eb051cbcc427173fba74dc9c2f6c309d7a3cc90f4917e6a10" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-osx64.tar.bz2#45ed8bf799d0fd8eb051cbcc427173fba74dc9c2f6c309d7a3cc90f4917e6a10" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-win32.zip#c53f0946703f5e4885484c7cde2554a0320537135bf8965e054757c214412438" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-5.0.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-win32.zip#c53f0946703f5e4885484c7cde2554a0320537135bf8965e054757c214412438" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.0.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-5.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-5.0.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.0-src.tar.bz2#89027b1b33553b53ff7733dc4838f0a76af23552c0d915d9f6de5875b8d7d4ab" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.0.1
+++ b/plugins/python-build/share/python-build/pypy-5.0.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux.tar.bz2#4b9a294033f917a1674c9ddcb2e7e8d32c4f4351f8216fd1fe23f6d2ad2b1a36" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.0.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armel.tar.bz2#17d55804b2253acd9de42276d756d4a08b7d1d2da09ef81dd325e14b18a1bcda" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armel.tar.bz2#17d55804b2253acd9de42276d756d4a08b7d1d2da09ef81dd325e14b18a1bcda" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.0.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armhf-raspbian.tar.bz2#338d1c32c1326e6321b222ae357711b38c4a0ffddf020c2a35536b5f69376e28" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armhf-raspbian.tar.bz2#338d1c32c1326e6321b222ae357711b38c4a0ffddf020c2a35536b5f69376e28" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.0.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armhf-raring.tar.bz2#1e9146978cc7e7bd30683a518f304a824db7b9b1c6fae5e866eb703684ba3c98" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux-armhf-raring.tar.bz2#1e9146978cc7e7bd30683a518f304a824db7b9b1c6fae5e866eb703684ba3c98" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.0.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux64.tar.bz2#1b1363a48edd1c1b31ca5e995987eda3d460a3404f36c3bb2dd9f52c93eecff5" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-linux64.tar.bz2#1b1363a48edd1c1b31ca5e995987eda3d460a3404f36c3bb2dd9f52c93eecff5" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_x86_64-portable.tar.bz2#14d65f84fe8228cfa2b8e924364cf4c71e2bc6b13649098fa340baf044606436" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_x86_64-portable.tar.bz2#14d65f84fe8228cfa2b8e924364cf4c71e2bc6b13649098fa340baf044606436" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.0.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-osx64.tar.bz2#6ebdb9d91203f053b38e3c21841c11a72f416dc185f7b3b7c908229df15e924a" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-osx64.tar.bz2#6ebdb9d91203f053b38e3c21841c11a72f416dc185f7b3b7c908229df15e924a" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.0.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-win32.zip#c12254d8b1747322736d26e014744a426c6900d232c1799140fbb43f44319730" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-5.0.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-win32.zip#c12254d8b1747322736d26e014744a426c6900d232c1799140fbb43f44319730" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.0.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.0.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-5.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-5.0.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.0.1-src.tar.bz2#1573c9284d3ec236c8e6ef3b954753932dff29462c54b5885b761d1ee68b6e05" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1
+++ b/plugins/python-build/share/python-build/pypy-5.1
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux.tar.bz2#2f6c521b5b3c1082eab58be78655aa01ec400d19baeec93c455864a7483b8744" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.1.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armel.tar.bz2#ea7017449ff0630431866423220c3688fc55c1a0b80a96af0ae138dd0751b81c" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armel.tar.bz2#ea7017449ff0630431866423220c3688fc55c1a0b80a96af0ae138dd0751b81c" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.1.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armhf-raspbian.tar.bz2#3bfcd251b4f3fd1a09520b2741c647c364d16d50c82b813732a78ac60ccb2b69" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armhf-raspbian.tar.bz2#3bfcd251b4f3fd1a09520b2741c647c364d16d50c82b813732a78ac60ccb2b69" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.1.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armhf-raring.tar.bz2#a3e13083591bccc301fb974ff0a6c7e4ab4e611e4b31c0932898b981c794462b" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux-armhf-raring.tar.bz2#a3e13083591bccc301fb974ff0a6c7e4ab4e611e4b31c0932898b981c794462b" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
   require_distro "Fedora 20" || true
-  install_package "pypy-5.1.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-ppc64.tar.bz2#32a31b9ff5174d69f8cf8db711ba2a593fed49b52bdf590bcecd6b727419b6df" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.0-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-ppc64.tar.bz2#32a31b9ff5174d69f8cf8db711ba2a593fed49b52bdf590bcecd6b727419b6df" "pypy" verify_py27 ensurepip
   ;;
 "linux-ppc64le" )
   require_distro "Fedora 21" || true
-  install_package "pypy-5.1.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-ppc64le.tar.bz2#303764f44154f81d7f0753258c89f8a14653658911a16ec2bcfee04055cbfab6" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.0-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-ppc64le.tar.bz2#303764f44154f81d7f0753258c89f8a14653658911a16ec2bcfee04055cbfab6" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-linux64.tar.bz2#0e8913351d043a50740b98cb89d99852b8bd6d11225a41c8abfc0baf7084cbf6" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.1.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-osx64.tar.bz2#7e270c66347158dd794c101c4817f742f760ed805aa0d10abe19ba4a78a75118" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-osx64.tar.bz2#7e270c66347158dd794c101c4817f742f760ed805aa0d10abe19ba4a78a75118" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.1.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-win32.zip#044e7f35223a443412b5948740e60e93069a6f8b0a72053cc9d472874bb1b6cc" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-5.1.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-win32.zip#044e7f35223a443412b5948740e60e93069a6f8b0a72053cc9d472874bb1b6cc" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-5.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-5.1.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.0-src.tar.bz2#16bab9501e942c0704abbf9cd6c4e950c6a76dc226cf1e447ea084916aef4714" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.1.1
+++ b/plugins/python-build/share/python-build/pypy-5.1.1
@@ -1,44 +1,44 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux.tar.bz2#7951fd2b87c9e621ec57c932c20da2b8a4a9e87d8daeb9e2b7373f9444219abc" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy-5.1.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armel.tar.bz2#062b33641c24dfc8c6b5af955c2ddf3815b471de0af4bfc343020651b94d13bf" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armel.tar.bz2#062b33641c24dfc8c6b5af955c2ddf3815b471de0af4bfc343020651b94d13bf" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy-5.1.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armhf-raspbian.tar.bz2#fc2a1f8719a7eca5d85d0bdcf499c6ab7409fc32aa312435bcbe66950b47e863" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armhf-raspbian.tar.bz2#fc2a1f8719a7eca5d85d0bdcf499c6ab7409fc32aa312435bcbe66950b47e863" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy-5.1.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armhf-raring.tar.bz2#c4bcdabccd15669ea44d1c715cd36b2ca55b340a27b63e1a92ef5ab6eb158a8d" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux-armhf-raring.tar.bz2#c4bcdabccd15669ea44d1c715cd36b2ca55b340a27b63e1a92ef5ab6eb158a8d" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux-ppc64" )
   require_distro "Fedora 20" || true
-  install_package "pypy-5.1.1-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-ppc64.tar.bz2#FIXME" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.1-ppc64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-ppc64.tar.bz2#FIXME" "pypy" verify_py27 ensurepip
   ;;
 "linux-ppc64le" )
   require_distro "Fedora 21" || true
-  install_package "pypy-5.1.1-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-ppc64le.tar.bz2#FIXME" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.1-ppc64le" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-ppc64le.tar.bz2#FIXME" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy-5.1.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux64.tar.bz2#c852622e8bc81618c137da35fcf57b2349b956c07b6fd853300846e3cefa64fc" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-linux64.tar.bz2#c852622e8bc81618c137da35fcf57b2349b956c07b6fd853300846e3cefa64fc" "pypy" verify_py27 ensurepip
   else
-    install_package "pypy-5.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_x86_64-portable.tar.bz2#c0502d8db1cc2b81513cc6047813669b0a561cb20e41d60e179f51fe8657a794" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy-5.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_x86_64-portable.tar.bz2#c0502d8db1cc2b81513cc6047813669b0a561cb20e41d60e179f51fe8657a794" "pypy" verify_py27 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy-5.1.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-osx64.tar.bz2#fe2bbb7cf95eb91b1724029f81e85d1dbb6025a2e9a005cfe7258fe07602f771" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-osx64.tar.bz2#fe2bbb7cf95eb91b1724029f81e85d1dbb6025a2e9a005cfe7258fe07602f771" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy-5.1.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-win32.zip#22a780e328ef053e098f2edc2302957ac3119adf7bf11ff23e225931806e7bcd" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy-5.1.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-win32.zip#22a780e328ef053e098f2edc2302957ac3119adf7bf11ff23e225931806e7bcd" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.1.1-src
+++ b/plugins/python-build/share/python-build/pypy-5.1.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy-5.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy-5.1.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy-5.1.1-src.tar.bz2#ca3d943d7fbd78bb957ee9e5833ada4bb8506ac99a41b7628790e286a65ed2be" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-5.3
+++ b/plugins/python-build/share/python-build/pypy-5.3
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.3.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux32.tar.bz2#bd422fe9d0b7d525d1da3f32855b047bc39ba397d0cf708d8f4f96fe874424f2" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy2-v5.3.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux32.tar.bz2#bd422fe9d0b7d525d1da3f32855b047bc39ba397d0cf708d8f4f96fe874424f2" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -14,19 +14,19 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy2-v5.3.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armel.tar.bz2#81b6f589a947d7353bb69408c46d4833d6e9cb501f3c3f0c73bd28d0e3df69aa" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy2-v5.3.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armel.tar.bz2#81b6f589a947d7353bb69408c46d4833d6e9cb501f3c3f0c73bd28d0e3df69aa" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy2-v5.3.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armhf-raspbian.tar.bz2#87b3566b6bbb8bf31c2f0d72bf31d95142fdce004d987812336a59d788005bed" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy2-v5.3.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armhf-raspbian.tar.bz2#87b3566b6bbb8bf31c2f0d72bf31d95142fdce004d987812336a59d788005bed" "pypy" verify_py27 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy2-v5.3.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armhf-raring.tar.bz2#bdb911a87e773a292334061b9c33b907f46d987e403fe94cc627a3b9b1c9cb19" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy2-v5.3.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux-armhf-raring.tar.bz2#bdb911a87e773a292334061b9c33b907f46d987e403fe94cc627a3b9b1c9cb19" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy2-v5.3.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux64.tar.bz2#ac336e8877ed676bf87a9a546d5926b6afc4679fa2d3fdf9f3ca56f28ec40588" "pypy" verify_py27 ensurepip verify_py27
+    install_package "pypy2-v5.3.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-linux64.tar.bz2#ac336e8877ed676bf87a9a546d5926b6afc4679fa2d3fdf9f3ca56f28ec40588" "pypy" verify_py27 ensurepip
   else
     { echo
       colorize 1 "ERROR"
@@ -38,11 +38,11 @@ case "$(pypy_architecture 2>/dev/null || true)" in
   fi
   ;;
 "osx64" )
-  install_package "pypy2-v5.3.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-osx64.tar.bz2#1b103bacbdcdbbc490660ec0c7b3d99d1ff1cfc2f13cd403db21c27f03d36a1d" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy2-v5.3.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-osx64.tar.bz2#1b103bacbdcdbbc490660ec0c7b3d99d1ff1cfc2f13cd403db21c27f03d36a1d" "pypy" verify_py27 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy2-v5.3.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-win32.zip#32a9e5286fc344165f63b529a9f84e521e9368e717c583488115654676428a20" "pypy" verify_py27 ensurepip verify_py27
+  install_zip "pypy2-v5.3.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-win32.zip#32a9e5286fc344165f63b529a9f84e521e9368e717c583488115654676428a20" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-5.3-src
+++ b/plugins/python-build/share/python-build/pypy-5.3-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy2-v5.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip verify_py27
+install_package "pypy2-v5.3.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.3.0-src.tar.bz2#4142eb8f403810bc88a4911792bb5a502e152df95806e33e69050c828cd160d5" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy-c-jit-latest
@@ -1,28 +1,28 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_nightly_package "pypy-c-jit-latest-linux" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux.tar.bz2" "pypy-c-jit-*-linux" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-jit-latest-linux" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux.tar.bz2" "pypy-c-jit-*-linux" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
-  install_nightly_package "pypy-c-jit-latest-linux-armel" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux-armel.tar.bz2" "pypy-c-jit-*-linux-armel" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-jit-latest-linux-armel" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux-armel.tar.bz2" "pypy-c-jit-*-linux-armel" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_nightly_package "pypy-c-jit-latest-linux-armhf-raspbian" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux-armhf-raspbian.tar.bz2" "pypy-c-jit-*-linux-armhf-raspbian" "pypy" verify_py27 ensurepip verify_py27
+    install_nightly_package "pypy-c-jit-latest-linux-armhf-raspbian" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux-armhf-raspbian.tar.bz2" "pypy-c-jit-*-linux-armhf-raspbian" "pypy" verify_py27 ensurepip
   else
-    install_nightly_package "pypy-c-jit-latest-linux-armhf-raring" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux-armhf-raring.tar.bz2" "pypy-c-jit-*-linux-armhf-raring" "pypy" verify_py27 ensurepip verify_py27
+    install_nightly_package "pypy-c-jit-latest-linux-armhf-raring" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux-armhf-raring.tar.bz2" "pypy-c-jit-*-linux-armhf-raring" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
-  install_nightly_package "pypy-c-jit-latest-linux64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux64.tar.bz2" "pypy-c-jit-*-linux64" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-jit-latest-linux64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-linux64.tar.bz2" "pypy-c-jit-*-linux64" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_nightly_package "pypy-c-jit-latest-osx64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-osx64.tar.bz2" "pypy-c-jit-*-osx64" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-jit-latest-osx64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-osx64.tar.bz2" "pypy-c-jit-*-osx64" "pypy" verify_py27 ensurepip
   ;;
 "freebsd64" )
-  install_nightly_package "pypy-c-jit-latest-freebsd64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-freebsd64.tar.bz2" "pypy-c-jit-*-freebsd64" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-jit-latest-freebsd64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-freebsd64.tar.bz2" "pypy-c-jit-*-freebsd64" "pypy" verify_py27 ensurepip
   ;;
 #"win32" )
-#  install_zip "pypy-c-jit-latest-win32" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-win32.zip" "pypy" verify_py27 ensurepip verify_py27
+#  install_zip "pypy-c-jit-latest-win32" "http://buildbot.pypy.org/nightly/trunk/pypy-c-jit-latest-win32.zip" "pypy" verify_py27 ensurepip
 #  ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-c-nojit-latest
+++ b/plugins/python-build/share/python-build/pypy-c-nojit-latest
@@ -1,28 +1,28 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_nightly_package "pypy-c-nojit-latest-linux" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux.tar.bz2" "pypy-c-nojit-*-linux" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-nojit-latest-linux" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux.tar.bz2" "pypy-c-nojit-*-linux" "pypy" verify_py27 ensurepip
   ;;
 "linux-armel" )
-  install_nightly_package "pypy-c-nojit-latest-linux-armel" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux-armel.tar.bz2" "pypy-c-nojit-*-linux-armel" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-nojit-latest-linux-armel" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux-armel.tar.bz2" "pypy-c-nojit-*-linux-armel" "pypy" verify_py27 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_nightly_package "pypy-c-nojit-latest-linux-armhf-raspbian" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux-armhf-raspbian.tar.bz2" "pypy-c-nojit-*-linux-armhf-raspbian" "pypy" verify_py27 ensurepip verify_py27
+    install_nightly_package "pypy-c-nojit-latest-linux-armhf-raspbian" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux-armhf-raspbian.tar.bz2" "pypy-c-nojit-*-linux-armhf-raspbian" "pypy" verify_py27 ensurepip
   else
-    install_nightly_package "pypy-c-nojit-latest-linux-armhf-raring" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux-armhf-raring.tar.bz2" "pypy-c-nojit-*-linux-armhf-raring" "pypy" verify_py27 ensurepip verify_py27
+    install_nightly_package "pypy-c-nojit-latest-linux-armhf-raring" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux-armhf-raring.tar.bz2" "pypy-c-nojit-*-linux-armhf-raring" "pypy" verify_py27 ensurepip
   fi
   ;;
 "linux64" )
-  install_nightly_package "pypy-c-nojit-latest-linux64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux64.tar.bz2" "pypy-c-nojit-*-linux64" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-nojit-latest-linux64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-linux64.tar.bz2" "pypy-c-nojit-*-linux64" "pypy" verify_py27 ensurepip
   ;;
 "osx64" )
-  install_nightly_package "pypy-c-nojit-latest-osx64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-osx64.tar.bz2" "pypy-c-nojit-*-osx64" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-nojit-latest-osx64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-osx64.tar.bz2" "pypy-c-nojit-*-osx64" "pypy" verify_py27 ensurepip
   ;;
 "freebsd64" )
-  install_nightly_package "pypy-c-nojit-latest-freebsd64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-freebsd64.tar.bz2" "pypy-c-nojit-*-freebsd64" "pypy" verify_py27 ensurepip verify_py27
+  install_nightly_package "pypy-c-nojit-latest-freebsd64" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-freebsd64.tar.bz2" "pypy-c-nojit-*-freebsd64" "pypy" verify_py27 ensurepip
   ;;
 #"win32" )
-#  install_zip "pypy-c-nojit-latest-win32" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-win32.zip" "pypy" verify_py27 ensurepip verify_py27
+#  install_zip "pypy-c-nojit-latest-win32" "http://buildbot.pypy.org/nightly/trunk/pypy-c-nojit-latest-win32.zip" "pypy" verify_py27 ensurepip
 #  ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-dev
+++ b/plugins/python-build/share/python-build/pypy-dev
@@ -1,2 +1,2 @@
 require_gcc
-install_hg "pypy-dev" "https://bitbucket.org/pypy/pypy" "default" "pypy_builder" verify_py27 ensurepip verify_py27
+install_hg "pypy-dev" "https://bitbucket.org/pypy/pypy" "default" "pypy_builder" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy-portable-2.3.1
+++ b/plugins/python-build/share/python-build/pypy-portable-2.3.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_i686-portable.tar.bz2#d8784020f6b8a5812fd8b3f5e1df8afb176fd56c2a929d4408d28d4a925525fa" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.3.1-linux_x86_64-portable.tar.bz2#453bd1291f0372e25ceab6b37b7a8d1756bebd3e708fcce1379ef931ccf9f75a" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-2.4
+++ b/plugins/python-build/share/python-build/pypy-portable-2.4
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_i686-portable.tar.bz2#2a330bbeae038c143366982f2104bf4096752f1ec7520fc5608f0527c124b0c2" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.4-linux_x86_64-portable.tar.bz2#b6ed31aff0ebcc9b40554576b1ce789fe4e8c93f7a34cd3983515e1a9a8a45b6" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-2.5
+++ b/plugins/python-build/share/python-build/pypy-portable-2.5
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-2.5-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_i686-portable.tar.bz2#6cbe3e1a48900f22c8e4412f82906fba92dd4a165bac5fe6866a2a26383fe3b8" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5-linux_x86_64-portable.tar.bz2#26c5a0964b32b09be0282766c27937c843a12b6820ff2d440c6d47a6092837e0" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-portable-2.5.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_i686-portable.tar.bz2#ed532ddde3332d10faa59af49854cacbca458c597889352e619a87ab22363063" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.5.1-linux_x86_64-portable.tar.bz2#157bee6349878cf0ef575b0d7bfd6cbb837c00e83b2872c924580ef7bc32c0d7" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-2.6
+++ b/plugins/python-build/share/python-build/pypy-portable-2.6
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-2.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_i686-portable.tar.bz2#e01db0984f7fecd80dadfb1d5f65118e596e3984d12643b4d552e83f92bff549" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6-linux_x86_64-portable.tar.bz2#97284b66476c5d1b17a62f5017569a0073730928e19f95b49d78d6bc60b69495" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-2.6.1
+++ b/plugins/python-build/share/python-build/pypy-portable-2.6.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_i686-portable.tar.bz2#af8f05790fe21bffdb0619d39f2890e2ecabe47bbd3b21c2c97b9778e4cdb378" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-2.6.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-2.6.1-linux_x86_64-portable.tar.bz2#ed6a35dee4c982123af716e62975039e18920b599afc4f6a2f3c7c89d0403389" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-4.0
+++ b/plugins/python-build/share/python-build/pypy-portable-4.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-4.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_i686-portable.tar.bz2#8d6b775a1fdc79db453f80e6b50cd9979d89be3714cd71d3af21bf9f56745610" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-4.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_x86_64-portable.tar.bz2#61fb04eaa823763b8de777e16edc02b09116985586f53c14c6e85d531072a38f" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0-linux_x86_64-portable.tar.bz2#61fb04eaa823763b8de777e16edc02b09116985586f53c14c6e85d531072a38f" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-4.0.1
+++ b/plugins/python-build/share/python-build/pypy-portable-4.0.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_i686-portable.tar.bz2#2a1078bf36372b1c2919c11c418860dd7f0d44c92e6772bb36490eaf793b5c47" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-4.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_x86_64-portable.tar.bz2#b3803f6dd9bbb964f7d322aa4aeb93191ff0ebe573428c1d2014ea26da49ff53" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-4.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-4.0.1-linux_x86_64-portable.tar.bz2#b3803f6dd9bbb964f7d322aa4aeb93191ff0ebe573428c1d2014ea26da49ff53" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-5.0
+++ b/plugins/python-build/share/python-build/pypy-portable-5.0
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-5.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_i686-portable.tar.bz2#316e03afdd2f6212857789933c01f0d41a1665c80d28526c0fb4082b6d3f4f60" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0-linux_x86_64-portable.tar.bz2#57c9ea251bf1e7074e14aeecdd1ac8bb2fc53dbf3f90a9613d03e33076a7fa08" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-5.0.1
+++ b/plugins/python-build/share/python-build/pypy-portable-5.0.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_i686-portable.tar.bz2#96f1b487655c914a03f56747dfff9c20350175cae01e2911f19b1016442ed6b5" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-5.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_x86_64-portable.tar.bz2#14d65f84fe8228cfa2b8e924364cf4c71e2bc6b13649098fa340baf044606436" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.0.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.0.1-linux_x86_64-portable.tar.bz2#14d65f84fe8228cfa2b8e924364cf4c71e2bc6b13649098fa340baf044606436" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-5.1
+++ b/plugins/python-build/share/python-build/pypy-portable-5.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_i686-portable.tar.bz2#893507603a58b8983b69924e60591de39b8f71f70ba36d6e3894db8f7c49c3ea" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1-linux_x86_64-portable.tar.bz2#b2df9b0127457d1c3cc0dc9b8f027a53569ccd3ba5a79012d641e576d9cc003a" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-portable-5.1.1
+++ b/plugins/python-build/share/python-build/pypy-portable-5.1.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_i686-portable.tar.bz2#f00faf426f41f9980344d03fd74bb949875c0cf86048ad762dd445f72353eb8f" "pypy" verify_py27 ensurepip
   ;;
 "linux64" )
-  install_package "pypy-5.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_x86_64-portable.tar.bz2#c0502d8db1cc2b81513cc6047813669b0a561cb20e41d60e179f51fe8657a794" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-5.1.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy-5.1.1-linux_x86_64-portable.tar.bz2#c0502d8db1cc2b81513cc6047813669b0a561cb20e41d60e179f51fe8657a794" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-stm-2.3
+++ b/plugins/python-build/share/python-build/pypy-stm-2.3
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" || true
-  install_package "pypy-stm-2.3-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-stm-2.3-linux64.tar.bz2#2a489280c679503442219782a87a2d16504a1467cac85ad4be1361a21d1f4d54" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-stm-2.3-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-stm-2.3-linux64.tar.bz2#2a489280c679503442219782a87a2d16504a1467cac85ad4be1361a21d1f4d54" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy-stm-2.5.1
+++ b/plugins/python-build/share/python-build/pypy-stm-2.5.1
@@ -1,7 +1,7 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux64" )
   require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" || true
-  install_package "pypy-stm-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-stm-2.5.1-linux64.tar.bz2#f280788002f2acf8690b8f9c479bb5b6f0e699ebb42f8bf203da3f70f1a38134" "pypy" verify_py27 ensurepip verify_py27
+  install_package "pypy-stm-2.5.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy-stm-2.5.1-linux64.tar.bz2#f280788002f2acf8690b8f9c479bb5b6f0e699ebb42f8bf203da3f70f1a38134" "pypy" verify_py27 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3-2.3.1
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.3.1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux.tar.bz2#7eddc6826e58c9c89e68b59ec8caf1596b76401517ad8d26ad5e18e0ffa45db9" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3-2.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armel.tar.bz2#37ccdc68df322ba1bafe4177593b4ca293d1fffd60d72f2cf2326d090677f04f" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.3.1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armel.tar.bz2#37ccdc68df322ba1bafe4177593b4ca293d1fffd60d72f2cf2326d090677f04f" "pypy" verify_py32 ensurepip
   ;;
 "linux-armhf")
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-2.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armhf-raspbian.tar.bz2#033ccca1e3d7156d05ca8accd58b6371e15efc17468bbc3f963625b0c829b66b" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.3.1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armhf-raspbian.tar.bz2#033ccca1e3d7156d05ca8accd58b6371e15efc17468bbc3f963625b0c829b66b" "pypy" verify_py32 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy3-2.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armhf-raring.tar.bz2#bd7c19bde4b18158da42534a677f27c9b23855968e7cc3d4178cc9d1620a250a" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.3.1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux-armhf-raring.tar.bz2#bd7c19bde4b18158da42534a677f27c9b23855968e7cc3d4178cc9d1620a250a" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.3.1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-linux64.tar.bz2#303df2cf4766db20ec77786d9091dce284fdab01d7173c5828a35e86bc931b99" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3-2.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-osx64.tar.bz2#600d4dad2039b8035582c0e0ce9b71e8236d95db26cff48c84c6d1e0ea6814c1" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.3.1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-osx64.tar.bz2#600d4dad2039b8035582c0e0ce9b71e8236d95db26cff48c84c6d1e0ea6814c1" "pypy" verify_py32 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-2.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-win32.zip#3f3566a39100da9b0fb730ff629352b48c5ae322546fce2c528c58fc0a652b26" "pypy" verify_py32 ensurepip verify_py32
+  install_zip "pypy3-2.3.1-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-win32.zip#3f3566a39100da9b0fb730ff629352b48c5ae322546fce2c528c58fc0a652b26" "pypy" verify_py32 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3-2.3.1-src
+++ b/plugins/python-build/share/python-build/pypy3-2.3.1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy3-2.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip verify_py32
+install_package "pypy3-2.3.1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.3.1-src.tar.bz2#924ca36bf85e02469c71d451c145f9a6d19b905df473a3d1c25179c63ea79d74" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-2.4.0
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0
@@ -1,36 +1,36 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.4.0-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux.tar.bz2#108fdcccfddb9b2cb2fc3cbca5e6f7902ed3ab74a24c8ae29da7fbdadbab4345" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" || true
-  install_package "pypy3-2.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armel.tar.bz2#322ddc863006a97d48edc302a73bb0981bbc142951237ed161ca0ca2cd02831f" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.4.0-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armel.tar.bz2#322ddc863006a97d48edc302a73bb0981bbc142951237ed161ca0ca2cd02831f" "pypy" verify_py32 ensurepip
   ;;
 "linux-armhf")
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3-2.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armhf-raspbian.tar.bz2#ad8f00255c85bf3c1012d56d5638c7aee12bc9f1ddcdaad35985bbd65a16c602" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.4.0-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armhf-raspbian.tar.bz2#ad8f00255c85bf3c1012d56d5638c7aee12bc9f1ddcdaad35985bbd65a16c602" "pypy" verify_py32 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy3-2.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armhf-raring.tar.bz2#eb41a3ee62741199aeeab818553ded460db991911609acf36e5710f491e5ac0a" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.4.0-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux-armhf-raring.tar.bz2#eb41a3ee62741199aeeab818553ded460db991911609acf36e5710f491e5ac0a" "pypy" verify_py32 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" 1>/dev/null 2>&1; then
-    install_package "pypy3-2.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.4.0-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-linux64.tar.bz2#24e680b1742af7361107876a421dd793f5ef852dd5f097546f84b1378f7f70cc" "pypy" verify_py32 ensurepip
   else
-    install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip verify_py32
+    install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3-2.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-osx64.tar.bz2#dcd86bdb753e93dbf55e1f3af3ffa97eea328b8b77aa60e92ea2260a6258cedb" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.4.0-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-osx64.tar.bz2#dcd86bdb753e93dbf55e1f3af3ffa97eea328b8b77aa60e92ea2260a6258cedb" "pypy" verify_py32 ensurepip
   ;;
 "win32" )
   # FIXME: never tested on Windows
-  install_zip "pypy3-2.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-win32.zip#7ea499993b07405898dee9435836220d8c7b8abfa1b1f760c4a1c04b43945797" "pypy" verify_py32 ensurepip verify_py32
+  install_zip "pypy3-2.4.0-win32" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-win32.zip#7ea499993b07405898dee9435836220d8c7b8abfa1b1f760c4a1c04b43945797" "pypy" verify_py32 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3-2.4.0-src
+++ b/plugins/python-build/share/python-build/pypy3-2.4.0-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy3-2.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip verify_py32
+install_package "pypy3-2.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3-2.4.0-src.tar.bz2#d9ba207d6eecf8a0dc4414e9f4e92db1abd143e8cc6ec4a6bdcac75b29f104f3" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-dev
+++ b/plugins/python-build/share/python-build/pypy3-dev
@@ -1,2 +1,2 @@
 require_gcc
-install_hg "pypy3-dev" "https://bitbucket.org/pypy/pypy" "py3k" "pypy_builder" verify_py32 ensurepip verify_py32
+install_hg "pypy3-dev" "https://bitbucket.org/pypy/pypy" "py3k" "pypy_builder" verify_py32 ensurepip

--- a/plugins/python-build/share/python-build/pypy3-portable-2.3.1
+++ b/plugins/python-build/share/python-build/pypy3-portable-2.3.1
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.3.1-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_i686-portable.tar.bz2#32a5b3fd4299b13aedf7bc6262eee0f6be9a27744ccf787718553d973ec38abb" "pypy" verify_py32 ensurepip
   ;;
 "linux64" )
-  install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.3.1-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.3.1-linux_x86_64-portable.tar.bz2#cb56b5bde8f444d44a0ea9cd475ddeed00aa895f3dcc89fd37577a51439540aa" "pypy" verify_py32 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3-portable-2.4
+++ b/plugins/python-build/share/python-build/pypy3-portable-2.4
@@ -1,9 +1,9 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
-  install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.4-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_i686-portable.tar.bz2#7ce050b4928dc58f7e9dd01e3e48c443c85616ca83f4bcc9147f1078d0fd126c" "pypy" verify_py32 ensurepip
   ;;
 "linux64" )
-  install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip verify_py32
+  install_package "pypy3-2.4-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3-2.4-linux_x86_64-portable.tar.bz2#7b3e0f0bc924bd0d68d85c0b566979e74a2b366595db3d81502267367370a5fb" "pypy" verify_py32 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1
@@ -1,32 +1,32 @@
 case "$(pypy_architecture 2>/dev/null || true)" in
 "linux" )
   if require_distro "Ubuntu 10.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.3-v5.2.0-alpha1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip verify_py33
+    install_package "pypy3.3-v5.2.0-alpha1-linux" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux32.tar.bz2#351aec101bdedddae7ea1b63845a5654b1a95fc9393894ef84a66749f6945f17" "pypy" verify_py33 ensurepip
   else
-    install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip verify_py33
+    install_package "pypy3.3-5.2-alpha-20160602-linux_i686-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_i686-portable.tar.bz2#6f2412167c63d6711b41062a23794828f95a75400082a6957595867762cb170d" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux-armel" )
   require_distro "Ubuntu 12.04" || true
-  install_package "pypy3.3-v5.2.0-alpha1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armel.tar.bz2#ac83e632213f078ab60045e6ad0564b146d65dcd9a52c130026fab6dd85bf2dc" "pypy" verify_py33 ensurepip verify_py33
+  install_package "pypy3.3-v5.2.0-alpha1-linux-armel" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armel.tar.bz2#ac83e632213f078ab60045e6ad0564b146d65dcd9a52c130026fab6dd85bf2dc" "pypy" verify_py33 ensurepip
   ;;
 "linux-armhf" )
   if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
-    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian.tar.bz2#ba9a5d0cbac1c622363315b30df288ab2cf8fcccf7e2882bf5946115dbfa657e" "pypy" verify_py33 ensurepip verify_py33
+    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armhf-raspbian.tar.bz2#ba9a5d0cbac1c622363315b30df288ab2cf8fcccf7e2882bf5946115dbfa657e" "pypy" verify_py33 ensurepip
   else
     require_distro "Ubuntu 13.04" || true
-    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armhf-raring.tar.bz2#b4d847d33c1bf9b3956d1d17b9e37505eb32f68e341c9333a74a82010a63e799" "pypy" verify_py33 ensurepip verify_py33
+    install_package "pypy3.3-v5.2.0-alpha1-linux-armhf-raring" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux-armhf-raring.tar.bz2#b4d847d33c1bf9b3956d1d17b9e37505eb32f68e341c9333a74a82010a63e799" "pypy" verify_py33 ensurepip
   fi
   ;;
 "linux64" )
   if require_distro "Ubuntu 12.04" "Ubuntu 12.10" "Ubuntu 13.04" "Ubuntu 13.10" "Ubuntu 14.04" 1>/dev/null 2>&1; then
-    install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip verify_py33
+    install_package "pypy3.3-v5.2.0-alpha1-linux64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-linux64.tar.bz2#f5e66ab24267d6ddf662d07c512d06c10ebc732ae62093dabbd775ac63b9060a" "pypy" verify_py33 ensurepip
   else
-    install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip verify_py33
+    install_package "pypy3.3-5.2-alpha-20160602-linux_x86_64-portable" "https://bitbucket.org/squeaky/portable-pypy/downloads/pypy3.3-5.2-alpha-20160602-linux_x86_64-portable.tar.bz2#4d1e7dd727448c1b2caa90c943713c0aa10b32e9d977c2c3b348835f515a3ad4" "pypy" verify_py33 ensurepip
   fi
   ;;
 "osx64" )
-  install_package "pypy3.3-v5.2.0-alpha1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-osx64.tar.bz2#abaceab5d2790f49e04e0d80669283da41f94b77cf483b30ac0de48d3c19f304" "pypy" verify_py33 ensurepip verify_py33
+  install_package "pypy3.3-v5.2.0-alpha1-osx64" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-osx64.tar.bz2#abaceab5d2790f49e04e0d80669283da41f94b77cf483b30ac0de48d3c19f304" "pypy" verify_py33 ensurepip
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
+++ b/plugins/python-build/share/python-build/pypy3.3-5.2-alpha1-src
@@ -1,2 +1,2 @@
 require_gcc
-install_package "pypy3.3-v5.2.0-alpha1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip verify_py33
+install_package "pypy3.3-v5.2.0-alpha1-src" "https://bitbucket.org/pypy/pypy/downloads/pypy3.3-v5.2.0-alpha1-src.tar.bz2#344c2f088c82ea1274964bb0505ab80d3f9e538cc03f91aa109325ddbaa61426" "pypy_builder" verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7-dev
+++ b/plugins/python-build/share/python-build/stackless-2.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-2.7-dev" "http://hg.python.org/stackless" "2.7-slp" standard verify_py27 ensurepip verify_py27
+install_hg "stackless-2.7-dev" "http://hg.python.org/stackless" "2.7-slp" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.2
+++ b/plugins/python-build/share/python-build/stackless-2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-272-export" "http://www.stackless.com/binaries/stackless-272-export.tar.bz2#e2e2706b22839e3e3f45085d0ec8030dd7374d8a65d3297981b7189a7c613197" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-272-export" "http://www.stackless.com/binaries/stackless-272-export.tar.bz2#e2e2706b22839e3e3f45085d0ec8030dd7374d8a65d3297981b7189a7c613197" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.3
+++ b/plugins/python-build/share/python-build/stackless-2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-273-export" "http://www.stackless.com/binaries/stackless-273-export.tar.bz2#77bee863bfd16dc4eca7fc078b12db608db7dd6e2481981bb68250118e001dfc" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-273-export" "http://www.stackless.com/binaries/stackless-273-export.tar.bz2#77bee863bfd16dc4eca7fc078b12db608db7dd6e2481981bb68250118e001dfc" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.4
+++ b/plugins/python-build/share/python-build/stackless-2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-274-export" "http://www.stackless.com/binaries/stackless-274-export.tar.bz2#ba566b18c66b095b65addbcfc4d814fc84f163c9fcffa1d0678755c581e64f45" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-274-export" "http://www.stackless.com/binaries/stackless-274-export.tar.bz2#ba566b18c66b095b65addbcfc4d814fc84f163c9fcffa1d0678755c581e64f45" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.5
+++ b/plugins/python-build/share/python-build/stackless-2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-275-export" "http://www.stackless.com/binaries/stackless-275-export.tar.bz2#5a389357762b32c590e1154a86b098cc379c71d10238b458a3e9b4fa4aac60d4" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-275-export" "http://www.stackless.com/binaries/stackless-275-export.tar.bz2#5a389357762b32c590e1154a86b098cc379c71d10238b458a3e9b4fa4aac60d4" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.6
+++ b/plugins/python-build/share/python-build/stackless-2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-276-export" "http://www.stackless.com/binaries/stackless-276-export.tar.bz2#1e905deaf74e8922f49b99139aa48e6670e9456c55fec8e60c47501f78c38ff5" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-276-export" "http://www.stackless.com/binaries/stackless-276-export.tar.bz2#1e905deaf74e8922f49b99139aa48e6670e9456c55fec8e60c47501f78c38ff5" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.7
+++ b/plugins/python-build/share/python-build/stackless-2.7.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-dev-stackless-a182f63395c3" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.7-slp.tar.bz2#88ca1169d878fd860f6d04d9e509399f2bc25ec0b692fd5998640c5d0d489c85" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-dev-stackless-a182f63395c3" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.7-slp.tar.bz2#88ca1169d878fd860f6d04d9e509399f2bc25ec0b692fd5998640c5d0d489c85" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.8
+++ b/plugins/python-build/share/python-build/stackless-2.7.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-dev-stackless-ff29dd4f67de" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.8-slp.tar.bz2#4d61c630c9a6c445b03c3b1a7d2391d5014a89d55b6d9d94be561fea34f158dc" ldflags_dirs standard verify_py27 ensurepip verify_py27
+install_package "stackless-dev-stackless-ff29dd4f67de" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.8-slp.tar.bz2#4d61c630c9a6c445b03c3b1a7d2391d5014a89d55b6d9d94be561fea34f158dc" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.3-dev
+++ b/plugins/python-build/share/python-build/stackless-3.3-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-3.3-dev" "http://hg.python.org/stackless" "3.3-slp" standard verify_py33 ensurepip verify_py33
+install_hg "stackless-3.3-dev" "http://hg.python.org/stackless" "3.3-slp" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.3.5
+++ b/plugins/python-build/share/python-build/stackless-3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-dev-stackless-c856cc204b1c" "https://bitbucket.org/stackless-dev/stackless/get/v3.3.5-slp.tar.bz2#197b41ccd7ec998ff612c67df9b8eb827a58f4eda715ca034c43c94bf17d5c0f" ldflags_dirs standard verify_py33 ensurepip verify_py33
+install_package "stackless-dev-stackless-c856cc204b1c" "https://bitbucket.org/stackless-dev/stackless/get/v3.3.5-slp.tar.bz2#197b41ccd7ec998ff612c67df9b8eb827a58f4eda715ca034c43c94bf17d5c0f" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.1
+++ b/plugins/python-build/share/python-build/stackless-3.4.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-dev-stackless-983d1323d146" "https://bitbucket.org/stackless-dev/stackless/get/v3.4.1-slp.tar.bz2#cae24c9d1d9b9ffd27d3ed0d9baae980df4a55fb27c497ef939709a3950ba538" ldflags_dirs standard verify_py34 ensurepip verify_py34
+install_package "stackless-dev-stackless-983d1323d146" "https://bitbucket.org/stackless-dev/stackless/get/v3.4.1-slp.tar.bz2#cae24c9d1d9b9ffd27d3ed0d9baae980df4a55fb27c497ef939709a3950ba538" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-dev
+++ b/plugins/python-build/share/python-build/stackless-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-dev" "http://hg.python.org/stackless" "default" standard verify_py35 ensurepip verify_py35
+install_hg "stackless-dev" "http://hg.python.org/stackless" "default" standard verify_py35 ensurepip


### PR DESCRIPTION
The original change has made for as a workaround of #638. Though it'd be just better to keep build definitions simple as possible.