### PR TITLE
Use xz archive instead of gzip archive

### DIFF
--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tgz#eda8ce6eec03e74991abb5384170e7c65fcd7522e409b8e83d7e6372add0f12a" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tgz#82929b96fd6afc8da838b149107078c02fa1744b7e60999a8babbc0d3fa86fc6" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.12
+++ b/plugins/python-build/share/python-build/2.7.12
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tgz#3cb522d17463dfa69a155ab18cffa399b358c966c0363d6c8b5b3bf1384da4b6" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tgz#7f49c0a6705ad89d925181e27d0aaa025ee4731ce0de64776c722216c3e66c42" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tgz#74d70b914da4487aa1d97222b29e9554d042f825f26cb2b93abd20fdda56b557" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tgz#c8bba33e66ac3201dabdc556f0ea7cfe6ac11946ec32d357c4c6f9b018c12c5b" ldflags_dirs standard verify_py27 ensurepip
+install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/3.2.6
+++ b/plugins/python-build/share/python-build/3.2.6
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tgz#fc1e41296e29d476f696303acae293ae7a2310f0f9d0d637905e722a3f16163e" ldflags_dirs standard verify_py32
+install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tar.xz#1d12b501819fd26afafbf8459be1aa279b56f032b4c15412de0a713ce0de7bdc" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.3.6
+++ b/plugins/python-build/share/python-build/3.3.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tgz#0a58ad1f1def4ecc90b18b0c410a3a0e1a48cf7692c75d1f83d0af080e5d2034" ldflags_dirs standard verify_py33 ensurepip
+install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tar.xz#5226e4bf7a530c3ff2bcde0c94e0e09e59a8bcde0114fe0268bc925bdabb5d3f" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tgz#d2c83ea0217769a73e8b1ee33ffbca814903f8568e30f8d13e68e3d1f743449c" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tar.xz#f13686c0a2d45e7146759e9d5d1cbd8097a0606483c0cf7730e1e13f58b14cbe" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.1
+++ b/plugins/python-build/share/python-build/3.4.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tgz#8d007e3ef80b128a292be101201e75dec5480e5632e994771e7c231d17720b66" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tar.xz#c595a163104399041fcbe1c5c04db4c1da94f917b82ce89e8944c8edff7aedc4" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.2
+++ b/plugins/python-build/share/python-build/3.4.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tgz#44a3c1ef1c7ca3e4fd25242af80ed72da941203cb4ed1a8c1b724d9078965dd8" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz#1c6d9682d145c056537e477bbfa060ce727f9edd38df1827e0f970dcf04b2def" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.3
+++ b/plugins/python-build/share/python-build/3.4.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tgz#8b743f56e9e50bf0923b9e9c45dd927c071d7aa56cd46569d8818add8cf01147" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz#b5b3963533768d5fc325a4d7a6bd6f666726002d696f1d399ec06b043ea996b8" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.4
+++ b/plugins/python-build/share/python-build/3.4.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tgz#bc93e944025816ec360712b4c42d8d5f729eaed2b26585e9bc8844f93f0c382e" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tar.xz#a797d3820155ec6cb654a652b9acfb11792d4e7d568eef1f9199009e042b6ba2" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.5
+++ b/plugins/python-build/share/python-build/3.4.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tgz#997aca4dd8692f3c954658a3db11c1d0862bcbf8eadd6a164746eb33d317c034" ldflags_dirs standard verify_py34 ensurepip
+install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tar.xz#ee64b1c8a47461009abf25252332d29a4e587cb4f0c1c96aa793a3732e9d898a" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.5.0
+++ b/plugins/python-build/share/python-build/3.5.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tgz#584e3d5a02692ca52fce505e68ecd77248a6f2c99adf9db144a39087336b0fe0" ldflags_dirs standard verify_py35 ensurepip
+install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.1
+++ b/plugins/python-build/share/python-build/3.5.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tgz#687e067d9f391da645423c7eda8205bae9d35edc0c76ef5218dcbe4cc770d0d7" ldflags_dirs standard verify_py35 ensurepip
+install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.2
+++ b/plugins/python-build/share/python-build/3.5.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tgz#1524b840e42cf3b909e8f8df67c1724012c7dc7f9d076d4feef2d3eff031e8a0" ldflags_dirs standard verify_py35 ensurepip
+install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" ldflags_dirs standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.6.0a1
+++ b/plugins/python-build/share/python-build/3.6.0a1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.6.0a1" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a1.tgz#16336eefaec9adf2e8e0035ddb622076f78e0c9c49db1d962f018bfb3804935e" ldflags_dirs standard verify_py36 ensurepip
+install_package "Python-3.6.0a1" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a1.tar.xz#7528a7c78ef6f319fec4e3ab40aca22e398e40716772f6030b7f0ea97d3d273f" ldflags_dirs standard verify_py36 ensurepip


### PR DESCRIPTION
XZ could be better from perspective of download size.

* [x] Check if the archive is actually available
* [x] Update documentations about dependencies
  * We'd need to add `xz-utils`

Because XZ is _relatively new_, changing the compression algorithm may cause problem on very old system. Please comment to issue if you have any concern about this.