### PR TITLE
Split blacklist of conda's system executables

### DIFF
--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -11,9 +11,13 @@ conda_exists() {
   [ -n "${condas}" ]
 }
 
-conda_shim() {
-  sed -e 's/#.*//' "${BASH_SOURCE%/*}/conda.txt" | fgrep -q -x "${1##*/}"
-}
+shims=()
+for shim in $(cat "${BASH_SOURCE%/*}/conda.txt"); do
+  if [ -n "${shim%%#*}" ]; then
+    shims[${#shims[*]}]="${shim})return 0;;"
+  fi
+done
+eval "conda_shim(){ case \"\$1\" in ${shims[@]} *)return 1;;esac;}"
 
 # override `make_shims` to avoid conflict between pyenv-virtualenv's `envs.bash`
 # https://github.com/yyuu/pyenv-virtualenv/blob/v20160716/etc/pyenv.d/rehash/envs.bash

--- a/pyenv.d/rehash/conda.bash
+++ b/pyenv.d/rehash/conda.bash
@@ -12,45 +12,7 @@ conda_exists() {
 }
 
 conda_shim() {
-  case "${1##*/}" in
-  "curl" | "curl-config" )
-    return 0 # curl
-    ;;
-  "fc-cache" | "fc-cat" | "fc-list" | "fc-match" | "fc-pattern" | "fc-query" | "fc-scan" | "fc-validate" )
-    return 0 # fontconfig
-    ;;
-  "freetype-config" )
-    return 0 # freetype
-    ;;
-  "libpng-config" )
-    return 0 # libpng
-    ;;
-  "openssl" )
-    return 0 # openssl
-    ;;
-  "assistant" | "designer" | "lconvert" | "linguist" | "lrelease" | "lupdate" | "moc" | "pixeltool" | "qcollectiongenerator" | "qdbus" | "qdbuscpp2xml" | "qdbusviewer" | "qdbusxml2cpp" | "qhelpconverter" | "qhelpgenerator" | "qmake" | "qmlplugindump" | "qmlviewer" | "qtconfig" | "rcc" | "uic" | "xmlpatterns" | "xmlpatternsvalidator" )
-    return 0 # qtchooser
-    ;;
-  "redis-benchmark" | "redis-check-aof" | "redis-check-dump" | "redis-cli" | "redis-server" )
-    return 0 # redis
-    ;;
-  "sqlite3" )
-    return 0 # sqlite3
-    ;;
-  "xml2-config" )
-    return 0 # libxml2
-    ;;
-  "xslt-config" )
-    return 0 # libxslt
-    ;;
-  "xsltproc" )
-    return 0 # xsltproc
-    ;;
-  "unxz" | "xz" | "xzcat" | "xzcmd" | "xzdiff" | "xzegrep" | "xzfgrep" | "xzgrep" | "xzless" | "xzmore" )
-    return 0 # xz-utils
-    ;;
-  esac
-  return 1
+  sed -e 's/#.*//' "${BASH_SOURCE%/*}/conda.txt" | fgrep -q -x "${1##*/}"
 }
 
 # override `make_shims` to avoid conflict between pyenv-virtualenv's `envs.bash`

--- a/pyenv.d/rehash/conda.txt
+++ b/pyenv.d/rehash/conda.txt
@@ -1,0 +1,78 @@
+# curl
+curl
+curl-config
+# fontconfig
+fc-cache
+fc-cat
+fc-list
+fc-match
+fc-pattern
+fc-query
+fc-scan
+fc-validate
+# freetype
+freetype-config
+# libglib2.0-bin
+gapplication
+gdbus
+gresource
+gsettings
+gio-querymodules
+glib-compile-resources
+glib-compile-schemas
+# libpng
+libpng-config
+# libxml2
+xml2-config
+# libxml2-utils
+xmlcatalog
+xmllint
+# openssl
+openssl
+# qtchooser
+assistant
+designer
+lconvert
+linguist
+lrelease
+lupdate
+moc
+pixeltool
+qcollectiongenerator
+qdbus
+qdbuscpp2xml
+qdbusviewer
+qdbusxml2cpp
+qhelpconverter
+qhelpgenerator
+qmake
+qmlplugindump
+qmlviewer
+qtconfig
+rcc
+uic
+xmlpatterns
+xmlpatternsvalidator
+# redis
+redis-benchmark
+redis-check-aof
+redis-check-dump
+redis-cli
+redis-server
+# sqlite3
+sqlite3
+# xslt-config
+xslt-config
+# xsltproc
+xsltproc
+# xz
+unxz
+xz
+xzcat
+xzcmd
+xzdiff
+xzegrep
+xzfgrep
+xzgrep
+xzless
+xzmore


### PR DESCRIPTION
Now we don't need to modify hook script itself to tweak the blacklist.