### PR TITLE
make all http source urls https

### DIFF
--- a/plugins/python-build/share/python-build/2.1.3
+++ b/plugins/python-build/share/python-build/2.1.3
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" standard --if has_broken_mac_readline
-install_package "Python-2.1.3" "http://www.python.org/ftp/python/2.1.3/Python-2.1.3.tgz#1bcb5bb587948bc38f36db60e15c376009c56c66570e563a08a82bf7f227afb9" ldflags_dirs standard verify_py21
+install_package "readline-6.2" "https://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" standard --if has_broken_mac_readline
+install_package "Python-2.1.3" "https://www.python.org/ftp/python/2.1.3/Python-2.1.3.tgz#1bcb5bb587948bc38f36db60e15c376009c56c66570e563a08a82bf7f227afb9" ldflags_dirs standard verify_py21
 #install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 #install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.2.3
+++ b/plugins/python-build/share/python-build/2.2.3
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" standard --if has_broken_mac_readline
-install_package "Python-2.2.3" "http://www.python.org/ftp/python/2.2.3/Python-2.2.3.tgz#a8f92e6b89d47359fff0d1fbfe47f104afc77fd1cd5143e7332758b7bc100188" ldflags_dirs standard verify_py22
+install_package "readline-6.2" "https://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" standard --if has_broken_mac_readline
+install_package "Python-2.2.3" "https://www.python.org/ftp/python/2.2.3/Python-2.2.3.tgz#a8f92e6b89d47359fff0d1fbfe47f104afc77fd1cd5143e7332758b7bc100188" ldflags_dirs standard verify_py22
 #install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 #install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.3.7
+++ b/plugins/python-build/share/python-build/2.3.7
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.2" "http://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" standard --if has_broken_mac_readline
-install_package "Python-2.3.7" "http://www.python.org/ftp/python/2.3.7/Python-2.3.7.tgz#969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e" ldflags_dirs standard verify_py23
+install_package "readline-6.2" "https://ftpmirror.gnu.org/readline/readline-6.2.tar.gz#79a696070a058c233c72dd6ac697021cc64abd5ed51e59db867d66d196a89381" standard --if has_broken_mac_readline
+install_package "Python-2.3.7" "https://www.python.org/ftp/python/2.3.7/Python-2.3.7.tgz#969a9891dce9f50b13e54f9890acaf2be66715a5895bf9b11111f320c205b90e" ldflags_dirs standard verify_py23
 #install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 #install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4
+++ b/plugins/python-build/share/python-build/2.4
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4" "http://www.python.org/ftp/python/2.4/Python-2.4.tgz#ff746de0fae8691c082414b42a2bb172da8797e6e8ff66c9a39d2e452f7034e9" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4" "https://www.python.org/ftp/python/2.4/Python-2.4.tgz#ff746de0fae8691c082414b42a2bb172da8797e6e8ff66c9a39d2e452f7034e9" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.1
+++ b/plugins/python-build/share/python-build/2.4.1
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4.1" "http://www.python.org/ftp/python/2.4.1/Python-2.4.1.tgz#f449c3b167389324c525ad99d02376c518ac11e163dbbbc13bc88a5c7101fd00" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4.1" "https://www.python.org/ftp/python/2.4.1/Python-2.4.1.tgz#f449c3b167389324c525ad99d02376c518ac11e163dbbbc13bc88a5c7101fd00" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.2
+++ b/plugins/python-build/share/python-build/2.4.2
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4.2" "http://www.python.org/ftp/python/2.4.2/Python-2.4.2.tgz#2653e1846e87fd9b3ee287fefc965c80c54646548b4913a22265b0dd54493adf" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4.2" "https://www.python.org/ftp/python/2.4.2/Python-2.4.2.tgz#2653e1846e87fd9b3ee287fefc965c80c54646548b4913a22265b0dd54493adf" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.3
+++ b/plugins/python-build/share/python-build/2.4.3
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4.3" "http://www.python.org/ftp/python/2.4.3/Python-2.4.3.tgz#985a413932f5e31e6280b37da6b285a3a0b2748c6786643989ed9b23de97e2d5" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4.3" "https://www.python.org/ftp/python/2.4.3/Python-2.4.3.tgz#985a413932f5e31e6280b37da6b285a3a0b2748c6786643989ed9b23de97e2d5" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.4
+++ b/plugins/python-build/share/python-build/2.4.4
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4.4" "http://www.python.org/ftp/python/2.4.4/Python-2.4.4.tgz#92be6e20cbc3111d9dd0c016d72ef7914c23b879dc52df7ba28df97afbf12e2e" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4.4" "https://www.python.org/ftp/python/2.4.4/Python-2.4.4.tgz#92be6e20cbc3111d9dd0c016d72ef7914c23b879dc52df7ba28df97afbf12e2e" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.5
+++ b/plugins/python-build/share/python-build/2.4.5
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4.5" "http://www.python.org/ftp/python/2.4.5/Python-2.4.5.tgz#6ae6f67a388a7f70ed3a20eebab5aae995ee433089d1f1724095c62f4b7389a1" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4.5" "https://www.python.org/ftp/python/2.4.5/Python-2.4.5.tgz#6ae6f67a388a7f70ed3a20eebab5aae995ee433089d1f1724095c62f4b7389a1" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.4.6
+++ b/plugins/python-build/share/python-build/2.4.6
@@ -1,5 +1,5 @@
 require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.4.6" "http://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz#b03f269e826927f05c966cf4f4414f3c93ee2314960859e7f8375e24e82f8b02" ldflags_dirs standard verify_py24
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.4.6" "https://www.python.org/ftp/python/2.4.6/Python-2.4.6.tgz#b03f269e826927f05c966cf4f4414f3c93ee2314960859e7f8375e24e82f8b02" ldflags_dirs standard verify_py24
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.1" "https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#993804bb947d18508acee02141281c77d27677f8c14eaa64d6287a1c53ef01c8" python

--- a/plugins/python-build/share/python-build/2.5
+++ b/plugins/python-build/share/python-build/2.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5" "http://www.python.org/ftp/python/2.5/Python-2.5.tgz#d7bbf42e36003c6065cd19f3e67d283521858515ee923220f654131cebe1d8f2" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5" "https://www.python.org/ftp/python/2.5/Python-2.5.tgz#d7bbf42e36003c6065cd19f3e67d283521858515ee923220f654131cebe1d8f2" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.1
+++ b/plugins/python-build/share/python-build/2.5.1
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5.1" "http://www.python.org/ftp/python/2.5.1/Python-2.5.1.tgz#1f5caee846049ca30d996f9403eefdb996295c4af664867e35dcc5eb36e4e7e8" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5.1" "https://www.python.org/ftp/python/2.5.1/Python-2.5.1.tgz#1f5caee846049ca30d996f9403eefdb996295c4af664867e35dcc5eb36e4e7e8" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.2
+++ b/plugins/python-build/share/python-build/2.5.2
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5.2" "http://www.python.org/ftp/python/2.5.2/Python-2.5.2.tgz#834afe8a88adaf623b05ac5dd6700dd5bb5d0d5553fc74ad529359a3496e4ae3" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5.2" "https://www.python.org/ftp/python/2.5.2/Python-2.5.2.tgz#834afe8a88adaf623b05ac5dd6700dd5bb5d0d5553fc74ad529359a3496e4ae3" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.3
+++ b/plugins/python-build/share/python-build/2.5.3
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5.3" "http://www.python.org/ftp/python/2.5.3/Python-2.5.3.tgz#c3fee607d20a77dfb72ea2e627eb4d95d25c735603435abde62c57015a0445bd" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5.3" "https://www.python.org/ftp/python/2.5.3/Python-2.5.3.tgz#c3fee607d20a77dfb72ea2e627eb4d95d25c735603435abde62c57015a0445bd" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.4
+++ b/plugins/python-build/share/python-build/2.5.4
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5.4" "http://www.python.org/ftp/python/2.5.4/Python-2.5.4.tgz#3d3b205611ee503a38a9433d5645a571668420bb219242c7f51af85f05664da6" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5.4" "https://www.python.org/ftp/python/2.5.4/Python-2.5.4.tgz#3d3b205611ee503a38a9433d5645a571668420bb219242c7f51af85f05664da6" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.5
+++ b/plugins/python-build/share/python-build/2.5.5
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5.5" "http://www.python.org/ftp/python/2.5.5/Python-2.5.5.tgz#03be1019c4fe93daeb53ba9e4294bf22a8ed4cb854cbd57e24e16f6bf63e2392" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5.5" "https://www.python.org/ftp/python/2.5.5/Python-2.5.5.tgz#03be1019c4fe93daeb53ba9e4294bf22a8ed4cb854cbd57e24e16f6bf63e2392" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.5.6
+++ b/plugins/python-build/share/python-build/2.5.6
@@ -1,5 +1,5 @@
 #require_gcc
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.5.6" "http://www.python.org/ftp/python/2.5.6/Python-2.5.6.tgz#c2e4377597241b1065677d23327c04d0f41945d370c61a491cc88be367234c5d" ldflags_dirs standard verify_py25
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.5.6" "https://www.python.org/ftp/python/2.5.6/Python-2.5.6.tgz#c2e4377597241b1065677d23327c04d0f41945d370c61a491cc88be367234c5d" ldflags_dirs standard verify_py25
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 install_package "pip-1.3.1" "https://pypi.python.org/packages/source/p/pip/pip-1.3.1.tar.gz#145eaa5d1ea1b062663da1f3a97780d7edea4c63c68a37c463b1deedf7bb4957" python

--- a/plugins/python-build/share/python-build/2.6.6
+++ b/plugins/python-build/share/python-build/2.6.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.6" "http://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" ldflags_dirs standard verify_py26 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.6.6" "https://www.python.org/ftp/python/2.6.6/Python-2.6.6.tgz#372f66db46d773214e4619df1794a26449158f626138d4d2141a64c2f017fae1" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.7
+++ b/plugins/python-build/share/python-build/2.6.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.7" "http://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" ldflags_dirs standard verify_py26 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.6.7" "https://www.python.org/ftp/python/2.6.7/Python-2.6.7.tgz#a8093eace4cfd3e06b05f0deb5d765e3c6cec65908048640a8cadd7a948b3826" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.8
+++ b/plugins/python-build/share/python-build/2.6.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.8" "http://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" ldflags_dirs standard verify_py26 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.6.8" "https://www.python.org/ftp/python/2.6.8/Python-2.6.8.tgz#5bf02a75ffa2fcaa5a3cabb8201998519b045541975622316888ea468d9512f7" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.6.9
+++ b/plugins/python-build/share/python-build/2.6.9
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.6.9" "http://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" ldflags_dirs standard verify_py26 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.6.9" "https://www.python.org/ftp/python/2.6.9/Python-2.6.9.tgz#7277b1285d8a82f374ef6ebaac85b003266f7939b3f2a24a3af52f9523ac94db" ldflags_dirs standard verify_py26 ensurepip

--- a/plugins/python-build/share/python-build/2.7
+++ b/plugins/python-build/share/python-build/2.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7" "http://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7" "https://www.python.org/ftp/python/2.7/Python-2.7.tgz#5670dd6c0c93b0b529781d070852f7b51ce6855615b16afcd318341af2910fb5" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7-dev
+++ b/plugins/python-build/share/python-build/2.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_hg "Python-2.7-dev" "https://hg.python.org/cpython" "2.7" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.1
+++ b/plugins/python-build/share/python-build/2.7.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.1" "http://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7.1" "https://www.python.org/ftp/python/2.7.1/Python-2.7.1.tgz#ca13e7b1860821494f70de017202283ad73b1fb7bd88586401c54ef958226ec8" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.10
+++ b/plugins/python-build/share/python-build/2.7.10
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.10" "https://www.python.org/ftp/python/2.7.10/Python-2.7.10.tar.xz#1cd3730781b91caf0fa1c4d472dc29274186480161a150294c42ce9b5c5effc0" ldflags_dirs standard verify_py27 ensurepip
 else

--- a/plugins/python-build/share/python-build/2.7.11
+++ b/plugins/python-build/share/python-build/2.7.11
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.11" "https://www.python.org/ftp/python/2.7.11/Python-2.7.11.tar.xz#962b4c45af50124ea61f11a30deb4342fc0bc21126790fa1d7f6c79809413f46" ldflags_dirs standard verify_py27 ensurepip
 else

--- a/plugins/python-build/share/python-build/2.7.12
+++ b/plugins/python-build/share/python-build/2.7.12
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.12" "https://www.python.org/ftp/python/2.7.12/Python-2.7.12.tar.xz#d7837121dd5652a05fef807c361909d255d173280c4e1a4ded94d73d80a1f978" ldflags_dirs standard verify_py27 ensurepip
 else

--- a/plugins/python-build/share/python-build/2.7.2
+++ b/plugins/python-build/share/python-build/2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.2" "http://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7.2" "https://www.python.org/ftp/python/2.7.2/Python-2.7.2.tgz#1d54b7096c17902c3f40ffce7e5b84e0072d0144024184fff184a84d563abbb3" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.3
+++ b/plugins/python-build/share/python-build/2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.3" "http://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7.3" "https://www.python.org/ftp/python/2.7.3/Python-2.7.3.tgz#d4c20f2b5faf95999fd5fecb3f7d32071b0820516224a6d2b72932ab47a1cb8e" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.4
+++ b/plugins/python-build/share/python-build/2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.4" "http://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7.4" "https://www.python.org/ftp/python/2.7.4/Python-2.7.4.tgz#98c5eb9c8e65effcc0122112ba17a0bce880aa23ecb560af56b55eb55632b81a" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.5
+++ b/plugins/python-build/share/python-build/2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.5" "http://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7.5" "https://www.python.org/ftp/python/2.7.5/Python-2.7.5.tgz#8e1b5fa87b91835afb376a9c0d319d41feca07ffebc0288d97ab08d64f48afbf" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.6
+++ b/plugins/python-build/share/python-build/2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-2.7.6" "http://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-2.7.6" "https://www.python.org/ftp/python/2.7.6/Python-2.7.6.tgz#99c6860b70977befa1590029fae092ddb18db1d69ae67e8b9385b66ed104ba58" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/2.7.7
+++ b/plugins/python-build/share/python-build/2.7.7
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.7" "https://www.python.org/ftp/python/2.7.7/Python-2.7.7.tar.xz#2983e3cd089b30c50e2b2234f07c2ac4fb8a5df230ab8f2e1133a1d8b208da78" ldflags_dirs standard verify_py27 ensurepip
 else

--- a/plugins/python-build/share/python-build/2.7.8
+++ b/plugins/python-build/share/python-build/2.7.8
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.8" "https://www.python.org/ftp/python/2.7.8/Python-2.7.8.tar.xz#edde10a0cb7d14e2735e682882d5b287028d1485c456758154c19573db68075a" ldflags_dirs standard verify_py27 ensurepip
 else

--- a/plugins/python-build/share/python-build/2.7.9
+++ b/plugins/python-build/share/python-build/2.7.9
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-2.7.9" "https://www.python.org/ftp/python/2.7.9/Python-2.7.9.tar.xz#90d27e14ea7e03570026850e2e50ba71ad20b7eb31035aada1cf3def8f8d4916" ldflags_dirs standard verify_py27 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.0.1
+++ b/plugins/python-build/share/python-build/3.0.1
@@ -1,7 +1,7 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.0.1" "http://www.python.org/ftp/python/3.0.1/Python-3.0.1.tgz#7d5f2feae9035f1d3d9e6bb7f092dbf374d6bb4b25abd0d2d11f13bba1cb04de" ldflags_dirs standard verify_py30
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.0.1" "https://www.python.org/ftp/python/3.0.1/Python-3.0.1.tgz#7d5f2feae9035f1d3d9e6bb7f092dbf374d6bb4b25abd0d2d11f13bba1cb04de" ldflags_dirs standard verify_py30
 if [[ "Darwin" == "$(uname -s)" ]]; then
   # https://github.com/yyuu/pyenv/issues/456
   { echo

--- a/plugins/python-build/share/python-build/3.1
+++ b/plugins/python-build/share/python-build/3.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1" "http://www.python.org/ftp/python/3.1/Python-3.1.tgz#99a034cf574ea3c26412b0a0728126d7fd6ea9593d099d807a25d216ed031e6a" ldflags_dirs standard verify_py31
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1" "https://www.python.org/ftp/python/3.1/Python-3.1.tgz#99a034cf574ea3c26412b0a0728126d7fd6ea9593d099d807a25d216ed031e6a" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.1
+++ b/plugins/python-build/share/python-build/3.1.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.1" "http://www.python.org/ftp/python/3.1.1/Python-3.1.1.tgz#5d85d7bff11c4db44920af99f64f4227c816f897f6bfa9dd8a2611165ca5f0a1" ldflags_dirs standard verify_py31
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.1" "https://www.python.org/ftp/python/3.1.1/Python-3.1.1.tgz#5d85d7bff11c4db44920af99f64f4227c816f897f6bfa9dd8a2611165ca5f0a1" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.2
+++ b/plugins/python-build/share/python-build/3.1.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.2" "http://www.python.org/ftp/python/3.1.2/Python-3.1.2.tgz#dffbc0561a161a4a576c6059e6990a9859a0be16ba9b5736eabe4abbb2700d1c" ldflags_dirs standard verify_py31
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.2" "https://www.python.org/ftp/python/3.1.2/Python-3.1.2.tgz#dffbc0561a161a4a576c6059e6990a9859a0be16ba9b5736eabe4abbb2700d1c" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.3
+++ b/plugins/python-build/share/python-build/3.1.3
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.3" "http://www.python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" ldflags_dirs standard verify_py31
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.3" "https://www.python.org/ftp/python/3.1.3/Python-3.1.3.tgz#6311823aeda8be6a7a2b67caaeff48abce6626c9940ba7ed81f9c978666a36bd" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.4
+++ b/plugins/python-build/share/python-build/3.1.4
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.4" "http://www.python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" ldflags_dirs standard verify_py31
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.4" "https://www.python.org/ftp/python/3.1.4/Python-3.1.4.tgz#fadc05ea6d05360cff189944a85ecd2180bbc308784d168b350450e70bbdd846" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.1.5
+++ b/plugins/python-build/share/python-build/3.1.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.1.5" "http://www.python.org/ftp/python/3.1.5/Python-3.1.5.tgz#d12dae6d06f52ef6bf1271db4d5b4d14b5dd39813e324314e72b648ef1bc0103" ldflags_dirs standard verify_py31
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.1.5" "https://www.python.org/ftp/python/3.1.5/Python-3.1.5.tgz#d12dae6d06f52ef6bf1271db4d5b4d14b5dd39813e324314e72b648ef1bc0103" ldflags_dirs standard verify_py31
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-1.5.6" "https://pypi.python.org/packages/source/p/pip/pip-1.5.6.tar.gz#b1a4ae66baf21b7eb05a5e4f37c50c2706fa28ea1f8780ce8efe14dcd9f1726c" python

--- a/plugins/python-build/share/python-build/3.2
+++ b/plugins/python-build/share/python-build/3.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2" "http://www.python.org/ftp/python/3.2/Python-3.2.tgz#27b35bfcbbf01de9564c0265d72b58ba3ff3d56df0615765372f2aa09dc20da9" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.2" "https://www.python.org/ftp/python/3.2/Python-3.2.tgz#27b35bfcbbf01de9564c0265d72b58ba3ff3d56df0615765372f2aa09dc20da9" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2-dev
+++ b/plugins/python-build/share/python-build/3.2-dev
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_hg "Python-3.2-dev" "https://hg.python.org/cpython" "3.2" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.1
+++ b/plugins/python-build/share/python-build/3.2.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2.1" "http://www.python.org/ftp/python/3.2.1/Python-3.2.1.tgz#7cff29d984696d9fe8c7bea54da5b9ad36acef33ff5cf0d3e37e4d12fb21c572" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.2.1" "https://www.python.org/ftp/python/3.2.1/Python-3.2.1.tgz#7cff29d984696d9fe8c7bea54da5b9ad36acef33ff5cf0d3e37e4d12fb21c572" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.2
+++ b/plugins/python-build/share/python-build/3.2.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2.2" "http://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz#acc6a13cb4fed0b7e86716324a8437e326645b8076177eede5a0cad99ec0313c" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.2.2" "https://www.python.org/ftp/python/3.2.2/Python-3.2.2.tgz#acc6a13cb4fed0b7e86716324a8437e326645b8076177eede5a0cad99ec0313c" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.3
+++ b/plugins/python-build/share/python-build/3.2.3
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2.3" "http://www.python.org/ftp/python/3.2.3/Python-3.2.3.tgz#74c33e165edef7532cef95fd9a325a06878b5bfc8a5d038161573f283eaf9809" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.2.3" "https://www.python.org/ftp/python/3.2.3/Python-3.2.3.tgz#74c33e165edef7532cef95fd9a325a06878b5bfc8a5d038161573f283eaf9809" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.4
+++ b/plugins/python-build/share/python-build/3.2.4
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2.4" "http://www.python.org/ftp/python/3.2.4/Python-3.2.4.tgz#71c3139908ccc1c544ba1e331a3c22b3f1c09f562438a054fd6f4e2628de8b9a" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.2.4" "https://www.python.org/ftp/python/3.2.4/Python-3.2.4.tgz#71c3139908ccc1c544ba1e331a3c22b3f1c09f562438a054fd6f4e2628de8b9a" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.5
+++ b/plugins/python-build/share/python-build/3.2.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.2.5" "http://www.python.org/ftp/python/3.2.5/Python-3.2.5.tgz#5eae0ab92a0bb9e3a1bf9c7cd046bc3de58996b049bd894d095978b6b085099f" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.2.5" "https://www.python.org/ftp/python/3.2.5/Python-3.2.5.tgz#5eae0ab92a0bb9e3a1bf9c7cd046bc3de58996b049bd894d095978b6b085099f" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/3.2.6
+++ b/plugins/python-build/share/python-build/3.2.6
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.2.6" "https://www.python.org/ftp/python/3.2.6/Python-3.2.6.tar.xz#1d12b501819fd26afafbf8459be1aa279b56f032b4c15412de0a713ce0de7bdc" ldflags_dirs standard verify_py32
 else

--- a/plugins/python-build/share/python-build/3.3-dev
+++ b/plugins/python-build/share/python-build/3.3-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_hg "Python-3.3-dev" "https://hg.python.org/cpython" "3.3" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.0
+++ b/plugins/python-build/share/python-build/3.3.0
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.0" "http://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" ldflags_dirs standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.3.0" "https://www.python.org/ftp/python/3.3.0/Python-3.3.0.tgz#cfe531eaace2503e13a74addc7f4a89482e99f8b8fca51b469ae5c83f450604e" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.1
+++ b/plugins/python-build/share/python-build/3.3.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.1" "http://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" ldflags_dirs standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.3.1" "https://www.python.org/ftp/python/3.3.1/Python-3.3.1.tgz#671dc3632f311e63c6733703aa0a1ad90c99277ddc8299d39e487718a50319bd" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.2
+++ b/plugins/python-build/share/python-build/3.3.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.2" "http://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" ldflags_dirs standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.3.2" "https://www.python.org/ftp/python/3.3.2/Python-3.3.2.tgz#de664fca3b8e0ab20fb42bfed1a36e26f116f1853e88ada12dbc938761036172" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.3
+++ b/plugins/python-build/share/python-build/3.3.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.3" "http://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" ldflags_dirs standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.3.3" "https://www.python.org/ftp/python/3.3.3/Python-3.3.3.tgz#30b60839bfe0ae8a2dba11e909328459bb8ee4a258afe7494b06b2ceda080efc" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.4
+++ b/plugins/python-build/share/python-build/3.3.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.4" "http://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" ldflags_dirs standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.3.4" "https://www.python.org/ftp/python/3.3.4/Python-3.3.4.tgz#ea055db9dd004a6ecd7690abc9734573763686dd768122316bae2dfd026412af" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.5
+++ b/plugins/python-build/share/python-build/3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "Python-3.3.5" "http://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" ldflags_dirs standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "Python-3.3.5" "https://www.python.org/ftp/python/3.3.5/Python-3.3.5.tgz#916bc57dd8524dc27429bebae7b39d6942742cf9699b875b2b496a3d960c7168" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/3.3.6
+++ b/plugins/python-build/share/python-build/3.3.6
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.3.6" "https://www.python.org/ftp/python/3.3.6/Python-3.3.6.tar.xz#5226e4bf7a530c3ff2bcde0c94e0e09e59a8bcde0114fe0268bc925bdabb5d3f" ldflags_dirs standard verify_py33 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.4-dev
+++ b/plugins/python-build/share/python-build/3.4-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_hg "Python-3.4-dev" "https://hg.python.org/cpython" "3.4" standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/3.4.0
+++ b/plugins/python-build/share/python-build/3.4.0
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.0" "https://www.python.org/ftp/python/3.4.0/Python-3.4.0.tar.xz#f13686c0a2d45e7146759e9d5d1cbd8097a0606483c0cf7730e1e13f58b14cbe" ldflags_dirs standard verify_py34 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.4.1
+++ b/plugins/python-build/share/python-build/3.4.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.1" "https://www.python.org/ftp/python/3.4.1/Python-3.4.1.tar.xz#c595a163104399041fcbe1c5c04db4c1da94f917b82ce89e8944c8edff7aedc4" ldflags_dirs standard verify_py34 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.4.2
+++ b/plugins/python-build/share/python-build/3.4.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.2" "https://www.python.org/ftp/python/3.4.2/Python-3.4.2.tar.xz#1c6d9682d145c056537e477bbfa060ce727f9edd38df1827e0f970dcf04b2def" ldflags_dirs standard verify_py34 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.4.3
+++ b/plugins/python-build/share/python-build/3.4.3
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.3" "https://www.python.org/ftp/python/3.4.3/Python-3.4.3.tar.xz#b5b3963533768d5fc325a4d7a6bd6f666726002d696f1d399ec06b043ea996b8" ldflags_dirs standard verify_py34 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.4.4
+++ b/plugins/python-build/share/python-build/3.4.4
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.4" "https://www.python.org/ftp/python/3.4.4/Python-3.4.4.tar.xz#a797d3820155ec6cb654a652b9acfb11792d4e7d568eef1f9199009e042b6ba2" ldflags_dirs standard verify_py34 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.4.5
+++ b/plugins/python-build/share/python-build/3.4.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.4.5" "https://www.python.org/ftp/python/3.4.5/Python-3.4.5.tar.xz#ee64b1c8a47461009abf25252332d29a4e587cb4f0c1c96aa793a3732e9d898a" ldflags_dirs standard verify_py34 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.5-dev
+++ b/plugins/python-build/share/python-build/3.5-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_hg "Python-3.5-dev" "https://hg.python.org/cpython" "3.5" standard verify_py35 ensurepip

--- a/plugins/python-build/share/python-build/3.5.0
+++ b/plugins/python-build/share/python-build/3.5.0
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.0" "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz#d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91" ldflags_dirs standard verify_py35 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.5.1
+++ b/plugins/python-build/share/python-build/3.5.1
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.1" "https://www.python.org/ftp/python/3.5.1/Python-3.5.1.tar.xz#c6d57c0c366d9060ab6c0cdf889ebf3d92711d466cc0119c441dbf2746f725c9" ldflags_dirs standard verify_py35 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.5.2
+++ b/plugins/python-build/share/python-build/3.5.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.5.2" "https://www.python.org/ftp/python/3.5.2/Python-3.5.2.tar.xz#0010f56100b9b74259ebcd5d4b295a32324b58b517403a10d1a2aa7cb22bca40" ldflags_dirs standard verify_py35 ensurepip
 else

--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_hg "Python-3.6-dev" "https://hg.python.org/cpython" "default" standard verify_py36 ensurepip

--- a/plugins/python-build/share/python-build/3.6.0a4
+++ b/plugins/python-build/share/python-build/3.6.0a4
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 if has_tar_xz_support; then
   install_package "Python-3.6.0a4" "https://www.python.org/ftp/python/3.6.0/Python-3.6.0a4.tar.xz#63acec349d20de412682f64c013f7c3374c695430b44e1c0ef12076da1d7fd2c" ldflags_dirs standard verify_py36 ensurepip
 else

--- a/plugins/python-build/share/python-build/jython-2.5-dev
+++ b/plugins/python-build/share/python-build/jython-2.5-dev
@@ -1,5 +1,5 @@
 require_java
-install_hg "jython-2.5-dev" "http://hg.python.org/jython" "2.5" jython_builder
+install_hg "jython-2.5-dev" "https://hg.python.org/jython" "2.5" jython_builder
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 # pip (>= 1.3) does not work properly since it uses HTTPS for downloads
 # * https://github.com/yyuu/pyenv/issues/15

--- a/plugins/python-build/share/python-build/jython-2.5.3
+++ b/plugins/python-build/share/python-build/jython-2.5.3
@@ -1,5 +1,5 @@
 require_java
-install_jar "jython-2.5.3" "http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar#05405966cdfa57abc8e705dd6aab92b8240097ce709fb916c8a0dbcaa491f99e" jython
+install_jar "jython-2.5.3" "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.3/jython-installer-2.5.3.jar#05405966cdfa57abc8e705dd6aab92b8240097ce709fb916c8a0dbcaa491f99e" jython
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 # pip (>= 1.3) does not work properly since it uses HTTPS for downloads
 # * https://github.com/yyuu/pyenv/issues/15

--- a/plugins/python-build/share/python-build/jython-2.5.4-rc1
+++ b/plugins/python-build/share/python-build/jython-2.5.4-rc1
@@ -1,5 +1,5 @@
 require_java
-install_jar "jython-2.5.4-rc1" "http://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.4-rc1/jython-installer-2.5.4-rc1.jar#2fa6821ef506804ca77f87631a21878c11d743f8a7fa9ed26e55dfd7696204d1" jython
+install_jar "jython-2.5.4-rc1" "https://search.maven.org/remotecontent?filepath=org/python/jython-installer/2.5.4-rc1/jython-installer-2.5.4-rc1.jar#2fa6821ef506804ca77f87631a21878c11d743f8a7fa9ed26e55dfd7696204d1" jython
 install_package "setuptools-1.4.2" "https://pypi.python.org/packages/source/s/setuptools/setuptools-1.4.2.tar.gz#263986a60a83aba790a5bffc7d009ac88114ba4e908e5c90e453b3bf2155dbbd" python
 # pip (>= 1.3) does not work properly since it uses HTTPS for downloads
 # * https://github.com/yyuu/pyenv/issues/15

--- a/plugins/python-build/share/python-build/jython-dev
+++ b/plugins/python-build/share/python-build/jython-dev
@@ -1,5 +1,5 @@
 require_java
-install_hg "jython-dev" "http://hg.python.org/jython" "default" jython_builder ez_setup
+install_hg "jython-dev" "https://hg.python.org/jython" "default" jython_builder ez_setup
 # pip (>= 1.3) does not work properly since it uses HTTPS for downloads
 # * https://github.com/yyuu/pyenv/issues/15
 install_package "pip-1.2.1" "https://pypi.python.org/packages/source/p/pip/pip-1.2.1.tar.gz#12a9302acfca62cdc7bc5d83386cac3e0581db61ac39acdb3a4e766a16b88eb1" python

--- a/plugins/python-build/share/python-build/stackless-2.7-dev
+++ b/plugins/python-build/share/python-build/stackless-2.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-2.7-dev" "http://hg.python.org/stackless" "2.7-slp" standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_hg "stackless-2.7-dev" "https://hg.python.org/stackless" "2.7-slp" standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.2
+++ b/plugins/python-build/share/python-build/stackless-2.7.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-272-export" "http://www.stackless.com/binaries/stackless-272-export.tar.bz2#e2e2706b22839e3e3f45085d0ec8030dd7374d8a65d3297981b7189a7c613197" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-272-export" "https://www.stackless.com/binaries/stackless-272-export.tar.bz2#e2e2706b22839e3e3f45085d0ec8030dd7374d8a65d3297981b7189a7c613197" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.3
+++ b/plugins/python-build/share/python-build/stackless-2.7.3
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-273-export" "http://www.stackless.com/binaries/stackless-273-export.tar.bz2#77bee863bfd16dc4eca7fc078b12db608db7dd6e2481981bb68250118e001dfc" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-273-export" "https://www.stackless.com/binaries/stackless-273-export.tar.bz2#77bee863bfd16dc4eca7fc078b12db608db7dd6e2481981bb68250118e001dfc" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.4
+++ b/plugins/python-build/share/python-build/stackless-2.7.4
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-274-export" "http://www.stackless.com/binaries/stackless-274-export.tar.bz2#ba566b18c66b095b65addbcfc4d814fc84f163c9fcffa1d0678755c581e64f45" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-274-export" "https://www.stackless.com/binaries/stackless-274-export.tar.bz2#ba566b18c66b095b65addbcfc4d814fc84f163c9fcffa1d0678755c581e64f45" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.5
+++ b/plugins/python-build/share/python-build/stackless-2.7.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-275-export" "http://www.stackless.com/binaries/stackless-275-export.tar.bz2#5a389357762b32c590e1154a86b098cc379c71d10238b458a3e9b4fa4aac60d4" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-275-export" "https://www.stackless.com/binaries/stackless-275-export.tar.bz2#5a389357762b32c590e1154a86b098cc379c71d10238b458a3e9b4fa4aac60d4" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.6
+++ b/plugins/python-build/share/python-build/stackless-2.7.6
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-276-export" "http://www.stackless.com/binaries/stackless-276-export.tar.bz2#1e905deaf74e8922f49b99139aa48e6670e9456c55fec8e60c47501f78c38ff5" ldflags_dirs standard verify_py27 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-276-export" "https://www.stackless.com/binaries/stackless-276-export.tar.bz2#1e905deaf74e8922f49b99139aa48e6670e9456c55fec8e60c47501f78c38ff5" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.7
+++ b/plugins/python-build/share/python-build/stackless-2.7.7
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "stackless-dev-stackless-a182f63395c3" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.7-slp.tar.bz2#88ca1169d878fd860f6d04d9e509399f2bc25ec0b692fd5998640c5d0d489c85" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-2.7.8
+++ b/plugins/python-build/share/python-build/stackless-2.7.8
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "stackless-dev-stackless-ff29dd4f67de" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.8-slp.tar.bz2#4d61c630c9a6c445b03c3b1a7d2391d5014a89d55b6d9d94be561fea34f158dc" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.2-dev
+++ b/plugins/python-build/share/python-build/stackless-3.2-dev
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-3.2-dev" "http://hg.python.org/stackless" "3.2-slp" standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_hg "stackless-3.2-dev" "https://hg.python.org/stackless" "3.2-slp" standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/stackless-3.2.2
+++ b/plugins/python-build/share/python-build/stackless-3.2.2
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-322-export" "http://www.stackless.com/binaries/stackless-322-export.tar.bz2#779700f12b451a350fe7af4cd2849842adc7006dc83fe14712dd1a0999277b07" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-322-export" "https://www.stackless.com/binaries/stackless-322-export.tar.bz2#779700f12b451a350fe7af4cd2849842adc7006dc83fe14712dd1a0999277b07" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/stackless-3.2.5
+++ b/plugins/python-build/share/python-build/stackless-3.2.5
@@ -1,6 +1,6 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-325-export" "http://www.stackless.com/binaries/stackless-325-export.tar.bz2#b021125e578ddd267d38feee9e1cbdb675f6aab247a2b88f4494abcf23babb05" ldflags_dirs standard verify_py32
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-325-export" "https://www.stackless.com/binaries/stackless-325-export.tar.bz2#b021125e578ddd267d38feee9e1cbdb675f6aab247a2b88f4494abcf23babb05" ldflags_dirs standard verify_py32
 install_package "setuptools-17.1.1" "https://pypi.python.org/packages/source/s/setuptools/setuptools-17.1.1.tar.gz#5bf42dbf406fd58a41029f53cffff1c90db5de1c5e0e560b5545cf2ec949c431" python
 install_package "pip-7.1.2" "https://pypi.python.org/packages/source/p/pip/pip-7.1.2.tar.gz#ca047986f0528cfa975a14fb9f7f106271d4e0c3fe1ddced6c1db2e7ae57a477" python

--- a/plugins/python-build/share/python-build/stackless-3.3-dev
+++ b/plugins/python-build/share/python-build/stackless-3.3-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-3.3-dev" "http://hg.python.org/stackless" "3.3-slp" standard verify_py33 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_hg "stackless-3.3-dev" "https://hg.python.org/stackless" "3.3-slp" standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.3.5
+++ b/plugins/python-build/share/python-build/stackless-3.3.5
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "stackless-dev-stackless-c856cc204b1c" "https://bitbucket.org/stackless-dev/stackless/get/v3.3.5-slp.tar.bz2#197b41ccd7ec998ff612c67df9b8eb827a58f4eda715ca034c43c94bf17d5c0f" ldflags_dirs standard verify_py33 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.1
+++ b/plugins/python-build/share/python-build/stackless-3.4.1
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
 install_package "stackless-dev-stackless-983d1323d146" "https://bitbucket.org/stackless-dev/stackless/get/v3.4.1-slp.tar.bz2#cae24c9d1d9b9ffd27d3ed0d9baae980df4a55fb27c497ef939709a3950ba538" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-dev
+++ b/plugins/python-build/share/python-build/stackless-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "http://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "stackless-dev" "http://hg.python.org/stackless" "default" standard verify_py35 ensurepip
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_hg "stackless-dev" "https://hg.python.org/stackless" "default" standard verify_py35 ensurepip


### PR DESCRIPTION
Even if pyenv checks a hash for most things (which it doesn't for jython's hg), it doesn't say that to the user (which just tells them it's downloading a HTTP url then unzips and compiles it), and the cost of HTTPS nowadays is so nil that pyenv might as well use it for all the URLs.