### PR TITLE
Added pypy-5.4-src

### DIFF
--- a/plugins/python-build/share/python-build/pypy-5.4-src
+++ b/plugins/python-build/share/python-build/pypy-5.4-src
@@ -1,0 +1,2 @@
+require_gcc
+install_package "pypy2-v5.4.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.4.0-src.tar.bz2#d9568ebe9a14d0eaefde887d78f3cba63d665e95c0d234bb583932341f55a655" "pypy_builder" verify_py27 ensurepip


### PR DESCRIPTION
Tested in Ubuntu 16.04 up to the point that it downloaded and started translating ("Installing pypy2-v5.4.0-src..." message)