### PR TITLE
Only mv bin to bin.orig the first time, otherwise the mv will fail

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1470,7 +1470,9 @@ build_package_symlink_version_suffix() {
   if [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then
     if [ -e "${PREFIX_PATH}/bin" ]; then
       # Always create `bin` as symlink to framework path if the version was built with `--enable-frameowrk` (#590)
-      mv -f "${PREFIX_PATH}/bin" "${PREFIX_PATH}/bin.orig"
+      if [ ! -e "${PREFIX_PATH}/bin.orig" ]; then
+        mv -f "${PREFIX_PATH}/bin" "${PREFIX_PATH}/bin.orig"
+      fi
     fi
     # Only symlinks are installed in ${PREFIX_PATH}/bin
     ln -fs "${PREFIX_PATH}/Python.framework/Versions/Current/bin" "${PREFIX_PATH}/bin"


### PR DESCRIPTION
build_package_symlink_version_suffix is called twice. The second time, the mv will fail (as bin has already been moved to bin.orig), resulting in the build failing.

This patch performs the mv only the first time.