### PR TITLE
Remove `bin.orig` if it already exists

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1470,9 +1470,8 @@ build_package_symlink_version_suffix() {
   if [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then
     if [ -e "${PREFIX_PATH}/bin" ]; then
       # Always create `bin` as symlink to framework path if the version was built with `--enable-frameowrk` (#590)
-      if [ ! -e "${PREFIX_PATH}/bin.orig" ]; then
-        mv -f "${PREFIX_PATH}/bin" "${PREFIX_PATH}/bin.orig"
-      fi
+      rm -rf "${PREFIX_PATH}/bin.orig"
+      mv -f "${PREFIX_PATH}/bin" "${PREFIX_PATH}/bin.orig"
     fi
     # Only symlinks are installed in ${PREFIX_PATH}/bin
     ln -fs "${PREFIX_PATH}/Python.framework/Versions/Current/bin" "${PREFIX_PATH}/bin"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1470,7 +1470,9 @@ build_package_symlink_version_suffix() {
   if [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-framework"* ]]; then
     if [ -e "${PREFIX_PATH}/bin" ]; then
       # Always create `bin` as symlink to framework path if the version was built with `--enable-frameowrk` (#590)
-      mv -f "${PREFIX_PATH}/bin" "${PREFIX_PATH}/bin.orig"
+      if [ ! -e "${PREFIX_PATH}/bin.orig" ]; then
+        mv -f "${PREFIX_PATH}/bin" "${PREFIX_PATH}/bin.orig"
+      fi
     fi
     # Only symlinks are installed in ${PREFIX_PATH}/bin
     ln -fs "${PREFIX_PATH}/Python.framework/Versions/Current/bin" "${PREFIX_PATH}/bin"


### PR DESCRIPTION
The directory may exist if the `build_package_symlink_version_suffix` ran multiple times. This is a workaround for `mv` errors like `mv: x and y are identical`.