### PR TITLE
Stackless 3.4.2

### DIFF
--- a/plugins/python-build/share/python-build/stackless-2.7.9
+++ b/plugins/python-build/share/python-build/stackless-2.7.9
@@ -1,4 +1,0 @@
-#require_gcc
-install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
-install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-dev-stackless-43302de87df4" "https://bitbucket.org/stackless-dev/stackless/get/v2.7.9-slp.tar.bz2" ldflags_dirs standard verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.2
+++ b/plugins/python-build/share/python-build/stackless-3.4.2
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_package "stackless-dev-stackless-587417070fe4" "https://bitbucket.org/stackless-dev/stackless/get/v3.4.2-slp.tar.bz2" ldflags_dirs standard verify_py34 ensurepip

--- a/plugins/python-build/share/python-build/stackless-3.4.2
+++ b/plugins/python-build/share/python-build/stackless-3.4.2
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_package "stackless-dev-stackless-587417070fe4" "https://bitbucket.org/stackless-dev/stackless/get/v3.4.2-slp.tar.bz2" ldflags_dirs standard verify_py34 ensurepip
+install_package "stackless-dev-stackless-587417070fe4" "https://bitbucket.org/stackless-dev/stackless/get/v3.4.2-slp.tar.bz2#c3dbdde536fa6bf366fdbc3e957596487608ba11009758ce599357512eb74103" ldflags_dirs standard verify_py34 ensurepip


### PR DESCRIPTION
Tested on Ubuntu 16.04 64-bit up to the point where it installs.

By the way, I did not include a checksum as I could not find any at the repository, but since Bitbucket uses HTTPS anyway that should be ok?