### PR TITLE
Add Pyston 0.5.1

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -922,9 +922,6 @@ build_package_pyston() {
   mkdir -p "${PREFIX_PATH}/"
   cp -fR . "${PREFIX_PATH}/"
   chmod +x "${PREFIX_PATH}/"pyston
-  # FIXME ugly hack below adapted from
-  # https://github.com/dropbox/pyston/blob/master/docker/pyston/Dockerfile
-  ( cd "${PREFIX_PATH}/" && ./pyston virtualenv/virtualenv.py . )
 }
 
 build_package_ironpython() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -964,6 +964,10 @@ pypy_architecture() {
   esac
 }
 
+pyston_architecture() {
+  pypy_architecture
+}
+
 build_package_pypy() {
   build_package_copy
   mkdir -p "${PREFIX_PATH}/bin" "${PREFIX_PATH}/lib"

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -922,6 +922,9 @@ build_package_pyston() {
   mkdir -p "${PREFIX_PATH}/"
   cp -fR . "${PREFIX_PATH}/"
   chmod +x "${PREFIX_PATH}/"pyston
+  # FIXME ugly hack below adapted from
+  # https://github.com/dropbox/pyston/blob/master/docker/pyston/Dockerfile
+  ( cd "${PREFIX_PATH}/" && ./pyston virtualenv/virtualenv.py . )
 }
 
 build_package_ironpython() {

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -918,6 +918,15 @@ build_package_jython_builder() {
   ( cd "dist" && build_package_jython )
 }
 
+build_package_pyston() {
+  mkdir -p "${PREFIX_PATH}/"
+  cp -fR . "${PREFIX_PATH}/"
+  chmod +x "${PREFIX_PATH}/"pyston
+  # FIXME ugly hack below adapted from
+  # https://github.com/dropbox/pyston/blob/master/docker/pyston/Dockerfile
+  ( cd "${PREFIX_PATH}/" && ./pyston virtualenv/virtualenv.py . )
+}
+
 build_package_ironpython() {
   mkdir -p "${PREFIX_PATH}/bin"
   cp -fR . "${PREFIX_PATH}/bin"

--- a/plugins/python-build/share/python-build/pyston-0.5.1
+++ b/plugins/python-build/share/python-build/pyston-0.5.1
@@ -5,8 +5,15 @@ case "$(pyston_architecture 2>/dev/null || true)" in
   # pyston targets python 2.7.7 and does not have ensurepip, when attempting to
   # run https://bootstrap.pypa.io/get-pip.py it dumps core, see
   # https://github.com/dropbox/pyston/issues/1373
-  # FIXME: more ugly hacks because Olenna Tyrell would approve
+  # FIXME ugly hack below adapted from
+  # https://github.com/dropbox/pyston/blob/master/docker/pyston/Dockerfile
+  ( cd "${PREFIX_PATH}/" && ./pyston virtualenv/virtualenv.py . )
+  # activate the virtualenv so that we're using the correct pip and site-packages location
+  ( source "${PREFIX_PATH}/bin/activate" )
+  # FIXME: if this fails it should not break the installation
   ( cd "${PREFIX_PATH}/bin" && ./pip install https://github.com/dropbox/pyston/releases/download/v0.5.1/Cython-0.24-pyston.tar.gz && ./pip install git+git://github.com/numpy/numpy@v1.11.0 )
+  # deactivate the virtualenv
+  ( deactivate )
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pyston-0.5.1
+++ b/plugins/python-build/share/python-build/pyston-0.5.1
@@ -11,7 +11,7 @@ case "$(pyston_architecture 2>/dev/null || true)" in
 * )
   { echo
     colorize 1 "ERROR"
-    echo ": A Pyston 0.5.1 binary is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo ": A Pyston 0.5.1 binary is not available for $(pyston_architecture 2>/dev/null || true)."
     echo
   } >&2
   exit 1

--- a/plugins/python-build/share/python-build/pyston-0.5.1
+++ b/plugins/python-build/share/python-build/pyston-0.5.1
@@ -1,0 +1,19 @@
+case "$(pypy_architecture 2>/dev/null || true)" in
+"linux64" )
+  install_package "pyston-0.5.1-linux64" "https://github.com/dropbox/pyston/releases/download/v0.5.1/pyston-0.5.1-linux64.tar.gz#4b0d2ad2c19f6393b79adbb9312649d38cb8cb3daf0c8fdf8631465c7761bb79" "pyston" verify_py27
+  # disabling ensurepip avoids having installation aborted because of a coredump
+  # pyston targets python 2.7.7 and does not have ensurepip, when attempting to
+  # run https://bootstrap.pypa.io/get-pip.py it dumps core, see
+  # https://github.com/dropbox/pyston/issues/1373
+  # FIXME: more ugly hacks because Olenna Tyrell would approve
+  ( cd "${PREFIX_PATH}/bin" && ./pip install https://github.com/dropbox/pyston/releases/download/v0.5.1/Cython-0.24-pyston.tar.gz && ./pip install git+git://github.com/numpy/numpy@v1.11.0 )
+  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": A Pyston 0.5.1 binary is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pyston-0.5.1
+++ b/plugins/python-build/share/python-build/pyston-0.5.1
@@ -6,11 +6,11 @@ case "$(pyston_architecture 2>/dev/null || true)" in
   # run https://bootstrap.pypa.io/get-pip.py it dumps core, see
   # https://github.com/dropbox/pyston/issues/1373
   # activate the virtualenv so that we're using the correct pip and site-packages location
-  ( source "${PREFIX_PATH}/bin/activate" )
+  # ( source "${PREFIX_PATH}/bin/activate" )
   # FIXME: if this fails it should not break the installation
-  ( cd "${PREFIX_PATH}/bin" && ./pip install https://github.com/dropbox/pyston/releases/download/v0.5.1/Cython-0.24-pyston.tar.gz && ./pip install git+git://github.com/numpy/numpy@v1.11.0 )
+  # ( cd "${PREFIX_PATH}/bin" && ./pip install https://github.com/dropbox/pyston/releases/download/v0.5.1/Cython-0.24-pyston.tar.gz && ./pip install git+git://github.com/numpy/numpy@v1.11.0 )
   # deactivate the virtualenv
-  ( deactivate )
+  # ( deactivate )
   ;;
 * )
   { echo

--- a/plugins/python-build/share/python-build/pyston-0.5.1
+++ b/plugins/python-build/share/python-build/pyston-0.5.1
@@ -5,9 +5,6 @@ case "$(pyston_architecture 2>/dev/null || true)" in
   # pyston targets python 2.7.7 and does not have ensurepip, when attempting to
   # run https://bootstrap.pypa.io/get-pip.py it dumps core, see
   # https://github.com/dropbox/pyston/issues/1373
-  # FIXME ugly hack below adapted from
-  # https://github.com/dropbox/pyston/blob/master/docker/pyston/Dockerfile
-  ( cd "${PREFIX_PATH}/" && ./pyston virtualenv/virtualenv.py . )
   # activate the virtualenv so that we're using the correct pip and site-packages location
   ( source "${PREFIX_PATH}/bin/activate" )
   # FIXME: if this fails it should not break the installation

--- a/plugins/python-build/share/python-build/pyston-0.5.1
+++ b/plugins/python-build/share/python-build/pyston-0.5.1
@@ -1,4 +1,4 @@
-case "$(pypy_architecture 2>/dev/null || true)" in
+case "$(pyston_architecture 2>/dev/null || true)" in
 "linux64" )
   install_package "pyston-0.5.1-linux64" "https://github.com/dropbox/pyston/releases/download/v0.5.1/pyston-0.5.1-linux64.tar.gz#4b0d2ad2c19f6393b79adbb9312649d38cb8cb3daf0c8fdf8631465c7761bb79" "pyston" verify_py27
   # disabling ensurepip avoids having installation aborted because of a coredump

--- a/plugins/python-build/share/python-build/pyston-0.5.1-numpy
+++ b/plugins/python-build/share/python-build/pyston-0.5.1-numpy
@@ -1,1 +1,0 @@
-source "${BASH_SOURCE%/*}/pyston-0.5.1"

--- a/plugins/python-build/share/python-build/pyston-0.5.1-numpy
+++ b/plugins/python-build/share/python-build/pyston-0.5.1-numpy
@@ -1,0 +1,1 @@
+source "${BASH_SOURCE%/*}/pyston-0.5.1"


### PR DESCRIPTION
Tested on Ubuntu 16.04 up to the point where the Numpy tutorial at https://docs.scipy.org/doc/numpy-dev/user/quickstart.html works:

```python
$ python
Pyston v0.5.1 (rev abb4b132d260e5858a458462f71fd94955647195), targeting Python 2.7.7
>> import numpy
>> import numpy as np
>> a = np.arange(15).reshape(3, 5)
>> a
array([[ 0,  1,  2,  3,  4],
       [ 5,  6,  7,  8,  9],
       [10, 11, 12, 13, 14]])
>> a.shape
(3, 5)
>> a.ndim
2
>> a.dtype.name
'int64'
>> a.itemsize
8
>> type(a)
<type 'numpy.ndarray'>
>> b = np.array([6, 7, 8])
>> b
array([6, 7, 8])
>> type(b)
<type 'numpy.ndarray'>
>> 
```
This ended up a whole more hackish than I'd like, comments appreciated.