### PR TITLE
Stop using ucs4 as default unicode encoding on OS X

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1934,7 +1934,9 @@ fi
 
 # Compile with `--enable-unicode=ucs4` by default (#257)
 if [[ "$PYTHON_CONFIGURE_OPTS" != *"--enable-unicode="* ]]; then
-  package_option python configure --enable-unicode=ucs4
+  if ! is_mac; then
+    package_option python configure --enable-unicode=ucs4
+  fi
 fi
 
 # SSL Certificate error with older wget that does not support Server Name Indication (#60)

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -67,6 +67,10 @@ assert_build_log() {
   stub_make_install
   stub_make_install
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   install_fixture definitions/needs-yaml
   assert_success
 
@@ -92,6 +96,10 @@ OUT
   stub_make_install
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
+
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
 
   TMPDIR="$TMP" install_fixture --patch definitions/needs-yaml <<<""
   assert_success
@@ -121,6 +129,10 @@ OUT
   stub_make_install
   stub patch ' : echo patch "$@" | sed -E "s/\.[[:alnum:]]+$/.XXX/" >> build.log'
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   TMPDIR="$TMP" install_fixture --patch definitions/needs-yaml <<<"diff --git a/script.py"
   assert_success
 
@@ -149,6 +161,10 @@ OUT
   stub brew "--prefix libyaml : echo '$brew_libdir'" false
   stub_make_install
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   install_fixture definitions/needs-yaml
   assert_success
 
@@ -171,6 +187,10 @@ OUT
 
   stub brew "--prefix readline : echo '$readline_libdir'"
   stub_make_install
+
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
 
   run_inline_definition <<DEF
 install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
@@ -198,6 +218,10 @@ OUT
 
   stub brew
   stub_make_install
+
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
 
   export PYTHON_CONFIGURE_OPTS="CPPFLAGS=-I$readline_libdir/include LDFLAGS=-L$readline_libdir/lib"
   run_inline_definition <<DEF
@@ -317,6 +341,10 @@ OUT
 
   stub_make_install
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   export PYTHON_MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
 install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"
@@ -411,6 +439,10 @@ CONF
 
   stub apply 'echo apply "$@" >> build.log'
   stub_make_install
+
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
 
   export PYTHON_CONFIGURE="${TMP}/custom-configure"
   run_inline_definition <<DEF

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -366,6 +366,10 @@ OUT
 
   stub_make_install
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   export MAKE_INSTALL_OPTS="DOGE=\"such wow\""
   run_inline_definition <<DEF
 install_package "Python-3.2.1" "http://python.org/ftp/python/3.2.1/Python-3.2.1.tar.gz"

--- a/plugins/python-build/test/build.bats
+++ b/plugins/python-build/test/build.bats
@@ -223,7 +223,11 @@ OUT
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
 
+  # yyuu/pyenv#257
   stub uname '-s : echo Darwin'
+
+  stub uname '-s : echo Darwin'
+
   stub sysctl false
   stub_make_install
 
@@ -238,7 +242,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 2
 make install
 OUT
@@ -251,7 +255,11 @@ OUT
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
 
+  # yyuu/pyenv#257
   stub uname '-s : echo Darwin'
+
+  stub uname '-s : echo Darwin'
+
   stub sysctl '-n hw.ncpu : echo 4'
   stub_make_install
 
@@ -267,7 +275,7 @@ DEF
 
   assert_build_log <<OUT
 Python-3.2.1: CPPFLAGS="-I${TMP}/install/include " LDFLAGS="-L${TMP}/install/lib "
-Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib --enable-unicode=ucs4
+Python-3.2.1: --prefix=$INSTALL_ROOT --libdir=$INSTALL_ROOT/lib
 make -j 4
 make install
 OUT
@@ -281,6 +289,9 @@ OUT
   stub_make_install
 
   # yyuu/pyenv#222
+  stub uname '-s : echo FreeBSD'
+
+  # yyuu/pyenv#257
   stub uname '-s : echo FreeBSD'
 
   export -n MAKE_OPTS
@@ -361,6 +372,9 @@ OUT
   # yyuu/pyenv#222
   stub uname '-s : echo FreeBSD'
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo FreeBSD'
+
   MAKE= install_fixture definitions/vanilla-python
   assert_success
 
@@ -375,6 +389,9 @@ OUT
   stub_make_install
 
   # yyuu/pyenv#222
+  stub uname '-s : echo FreeBSD'
+
+  # yyuu/pyenv#257
   stub uname '-s : echo FreeBSD'
 
   MAKE= install_fixture definitions/vanilla-python

--- a/plugins/python-build/test/compiler.bats
+++ b/plugins/python-build/test/compiler.bats
@@ -12,6 +12,9 @@ export -n PYTHON_CONFIGURE_OPTS
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.9.5'
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
+
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.9.5'
   stub gcc '--version : echo 4.2.1'
@@ -32,6 +35,9 @@ OUT
   # yyuu/pyenv#222
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
+
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
 
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
@@ -67,6 +73,9 @@ DEF
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
+
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
   stub cc 'false'
@@ -89,7 +98,7 @@ build_package_standard python
 DEF
   assert_success
   assert_output <<OUT
-./configure --prefix=$INSTALL_ROOT --libdir=${TMP}/install/lib --enable-unicode=ucs4
+./configure --prefix=$INSTALL_ROOT --libdir=${TMP}/install/lib
 CC=clang
 CFLAGS=no
 make -j 2

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -234,6 +234,9 @@ OUT
   touch "${INSTALL_ROOT}/Python.framework/Versions/Current/bin/python3.4-config"
   chmod +x "${INSTALL_ROOT}/Python.framework/Versions/Current/bin/python3.4-config"
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
+
   stub uname '-s : echo Darwin'
 
   PYTHON_CONFIGURE_OPTS="--enable-framework" TMPDIR="$TMP" run_inline_definition <<OUT
@@ -242,7 +245,7 @@ verify_python python3.4
 OUT
   assert_success
   assert_output <<EOS
-PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-framework=${TMP}/install --enable-unicode=ucs4)
+PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-framework=${TMP}/install)
 EOS
 
   [ -L "${INSTALL_ROOT}/Python.framework/Versions/Current/bin/python" ]
@@ -250,6 +253,9 @@ EOS
 }
 
 @test "enable universalsdk" {
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
+
   stub uname '-s : echo Darwin'
 
   PYTHON_CONFIGURE_OPTS="--enable-universalsdk" TMPDIR="$TMP" run_inline_definition <<OUT
@@ -257,7 +263,7 @@ echo "PYTHON_CONFIGURE_OPTS_ARRAY=(\${PYTHON_CONFIGURE_OPTS_ARRAY[@]})"
 OUT
   assert_success
   assert_output <<EOS
-PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-universalsdk=/ --with-universal-archs=intel --enable-unicode=ucs4)
+PYTHON_CONFIGURE_OPTS_ARRAY=(--libdir=${TMP}/install/lib --enable-universalsdk=/ --with-universal-archs=intel)
 EOS
 }
 
@@ -283,6 +289,9 @@ OUT
 }
 
 @test "default MACOSX_DEPLOYMENT_TARGET" {
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
+
   stub uname '-s : echo Darwin'
   stub sw_vers '-productVersion : echo 10.10'
 
@@ -294,6 +303,9 @@ OUT
 }
 
 @test "use custom MACOSX_DEPLOYMENT_TARGET if defined" {
+  # yyuu/pyenv#257
+  stub uname '-s : echo Darwin'
+
   stub uname '-s : echo Darwin'
 
   MACOSX_DEPLOYMENT_TARGET="10.4" TMPDIR="$TMP" run_inline_definition <<OUT

--- a/plugins/python-build/test/pyenv_ext.bats
+++ b/plugins/python-build/test/pyenv_ext.bats
@@ -101,6 +101,10 @@ resolve_link() {
 
   echo | install_patch definitions/vanilla-python "Python-3.2.1/empty.patch"
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   TMPDIR="$TMP" install_tmp_fixture definitions/vanilla-python < /dev/null
   assert_success
 
@@ -127,6 +131,10 @@ OUT
   echo "bar" | install_patch definitions/vanilla-python "Python-3.2.1/bar.patch"
   echo "baz" | install_patch definitions/vanilla-python "Python-3.2.1/baz.patch"
 
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
+
   TMPDIR="$TMP" install_tmp_fixture definitions/vanilla-python < /dev/null
   assert_success
 
@@ -151,6 +159,10 @@ OUT
   stub "$MAKE" \
     " : echo \"$MAKE \$@\" >> build.log" \
     " : echo \"$MAKE \$@\" >> build.log && cat build.log >> '$INSTALL_ROOT/build.log'"
+
+  # yyuu/pyenv#257
+  stub uname '-s : echo Linux'
+  stub uname '-s : echo Linux'
 
   PYTHON_MAKE_INSTALL_TARGET="altinstall" TMPDIR="$TMP" install_tmp_fixture definitions/vanilla-python < /dev/null
   assert_success


### PR DESCRIPTION
This PR is follow up of discussion in https://github.com/yyuu/pyenv/issues/257

This lets python-build to stop configuring `--enable-unicode=ucs4`. It means that CPython built on OS X will use narrow encoding (UCS2) after this.

At least for now, this doesn't care platforms other than OS X; all BSDs will be managed just as similar as Linux distros in terms of encoding perspective. This may cause some binary incompatibility issue on some BSD families. I may be going to tweak the lines again if I got some issues from them.