### PR TITLE
Add 3.7-dev definition

### DIFF
--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1655,6 +1655,11 @@ build_package_verify_py36() {
   build_package_verify_py35 "$1" "${2:-3.6}"
 }
 
+# Post-install check for Python 3.7.x
+build_package_verify_py37() {
+  build_package_verify_py36 "$1" "${2:-3.7}"
+}
+
 build_package_ez_setup() {
   local ez_setup="ez_setup.py"
   rm -f "${ez_setup}"

--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,0 +1,4 @@
+#require_gcc
+install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
+install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
+install_hg "Python-3.7-dev" "https://hg.python.org/cpython" "default" standard verify_py37 ensurepip


### PR DESCRIPTION
As reported in https://github.com/travis-ci/travis-ci/issues/6599,
the "default" Python branch has moved on to "3.7-dev".