### PR TITLE
Point 3.6-dev to the 3.6 branch

### DIFF
--- a/plugins/python-build/share/python-build/3.6-dev
+++ b/plugins/python-build/share/python-build/3.6-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-3.6-dev" "https://hg.python.org/cpython" "default" standard verify_py36 ensurepip
+install_hg "Python-3.6-dev" "https://hg.python.org/cpython" "3.6" standard verify_py36 ensurepip


### PR DESCRIPTION
As reported in travis-ci/travis-ci#6599,
the "default" Python branch has moved on to "3.7-dev".