### PR TITLE
Pypy3.5-c-jit-latest nightly builds (please review)

### DIFF
--- a/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
@@ -1,3 +1,15 @@
+echo
+colorize 1 "WARNING"
+echo "This may eat your kittens/ affect timespace in alternate dimensions/"
+echo "cause you to complain more. Nightly builds are meant for testing only."
+echo "The PyPy team is interested in reports of what's already implemented, see:"
+echo
+echo "https://bitbucket.org/pypy/extradoc/src/c70f20cfb870/planning/py3.5/?at=extradoc"
+echo
+echo "for the latest status updates. To report bugs/regressions, please see:"
+echo
+echo "http://doc.pypy.org/en/latest/faq.html#how-should-i-report-a-bug"
+
 case "$(pypy_architecture 2>/dev/null || true)" in
 #"linux" )
 #  install_nightly_package "pypy-c-jit-latest-linux" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux.tar.bz2" "pypy-c-jit-*-linux" "pypy" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
@@ -40,7 +40,8 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 * )
   { echo
     colorize 1 "ERROR"
-    echo ": The binary distribution of PyPy 3.5 is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo ": The latest nightly build of PyPy 3.5 is not available for $(pypy_architecture 2>/dev/null || true),"
+    echo "Please check http://buildbot.pypy.org/nightly/py3.5/ for previous builds."
     echo
   } >&2
   exit 1

--- a/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
@@ -26,7 +26,7 @@ case "$(pypy_architecture 2>/dev/null || true)" in
 #  fi
 #  ;;
 "linux64" )
-  install_nightly_package "pypy3.5-c-jit-latest-linux64" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2" "pypy-c-jit-*-linux64" "pypy" # verify_py35 ensurepip
+  install_nightly_package "pypy3.5-c-jit-latest-linux64" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2" "pypy-c-jit-*-linux64" "pypy" verify_py35 ensurepip
   ;;
 #"osx64" )
 #  install_nightly_package "pypy-c-jit-latest-osx64" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-osx64.tar.bz2" "pypy-c-jit-*-osx64" "pypy" verify_py27 ensurepip

--- a/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
@@ -1,0 +1,35 @@
+case "$(pypy_architecture 2>/dev/null || true)" in
+#"linux" )
+#  install_nightly_package "pypy-c-jit-latest-linux" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux.tar.bz2" "pypy-c-jit-*-linux" "pypy" verify_py27 ensurepip
+#  ;;
+#"linux-armel" )
+#  install_nightly_package "pypy-c-jit-latest-linux-armel" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux-armel.tar.bz2" "pypy-c-jit-*-linux-armel" "pypy" verify_py27 ensurepip
+#  ;;
+#"linux-armhf" )
+#  if [[ "$(cat /etc/issue 2>/dev/null || true)" == "Raspbian"* ]]; then
+#    install_nightly_package "pypy-c-jit-latest-linux-armhf-raspbian" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux-armhf-raspbian.tar.bz2" "pypy-c-jit-*-linux-armhf-raspbian" "pypy" verify_py27 ensurepip
+#  else
+#    install_nightly_package "pypy-c-jit-latest-linux-armhf-raring" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux-armhf-raring.tar.bz2" "pypy-c-jit-*-linux-armhf-raring" "pypy" verify_py27 ensurepip
+#  fi
+#  ;;
+"linux64" )
+  install_nightly_package "pypy3.5-c-jit-latest-linux64" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2" "pypy-c-jit-*-linux64" "pypy" # verify_py35 ensurepip
+  ;;
+#"osx64" )
+#  install_nightly_package "pypy-c-jit-latest-osx64" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-osx64.tar.bz2" "pypy-c-jit-*-osx64" "pypy" verify_py27 ensurepip
+#  ;;
+#"freebsd64" )
+#  install_nightly_package "pypy-c-jit-latest-freebsd64" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-freebsd64.tar.bz2" "pypy-c-jit-*-freebsd64" "pypy" verify_py27 ensurepip
+#  ;;
+#"win32" )
+#  install_zip "pypy-c-jit-latest-win32" "http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-win32.zip" "pypy" verify_py27 ensurepip
+#  ;;
+* )
+  { echo
+    colorize 1 "ERROR"
+    echo ": The binary distribution of PyPy 3.5 is not available for $(pypy_architecture 2>/dev/null || true)."
+    echo
+  } >&2
+  exit 1
+  ;;
+esac

--- a/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
+++ b/plugins/python-build/share/python-build/pypy3.5-c-jit-latest
@@ -1,6 +1,6 @@
 echo
 colorize 1 "WARNING"
-echo "This may eat your kittens/ affect timespace in alternate dimensions/"
+echo ": This may eat your kittens/ affect timespace in alternate dimensions/"
 echo "cause you to complain more. Nightly builds are meant for testing only."
 echo "The PyPy team is interested in reports of what's already implemented, see:"
 echo
@@ -9,6 +9,7 @@ echo
 echo "for the latest status updates. To report bugs/regressions, please see:"
 echo
 echo "http://doc.pypy.org/en/latest/faq.html#how-should-i-report-a-bug"
+echo
 
 case "$(pypy_architecture 2>/dev/null || true)" in
 #"linux" )


### PR DESCRIPTION
Unfortunately last nightly build did not succeed so I can't test it right now:

http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2 is empty

so the output currently is:

```
Downloading pypy-c-jit-latest-linux64.tar.bz2...
-> http://buildbot.pypy.org/nightly/py3.5/pypy-c-jit-latest-linux64.tar.bz2
/home/samo/.pyenv/plugins/python-build/bin/python-build: línea 230: pushd: pypy3.5-c-jit-latest-linux64: No existe el archivo o el directorio

BUILD FAILED (Ubuntu 16.04 using python-build 1.0.0-94-geb2e5ac)

Inspect or clean up the working tree at /tmp/python-build.20161015133206.14884
Results logged to /tmp/python-build.20161015133206.14919.log

Last 10 log lines:
    Input file = (stdin), output file = (stdout)

It is possible that the compressed file(s) have become corrupted.
You can use the -tvv option to test integrity of such files.

You can use the `bzip2recover' program to attempt to recover
data from undamaged sections of corrupted files.

tar: Child returned status 2
tar: Error is not recoverable: exiting now
```

I'd like to find a way to catch an empty file and show the error message instead. Any suggestions appreciated.
