### PR TITLE
Add PyPy2 5.6.0 src

### DIFF
--- a/plugins/python-build/share/python-build/pypy-5.6.0-src
+++ b/plugins/python-build/share/python-build/pypy-5.6.0-src
@@ -1,0 +1,1 @@
+source "${BASH_SOURCE%/*}/pypy2-5.6.0-src"

--- a/plugins/python-build/share/python-build/pypy2-5.6.0-src
+++ b/plugins/python-build/share/python-build/pypy2-5.6.0-src
@@ -1,0 +1,2 @@
+require_gcc
+install_package "pypy2-v5.6.0-src" "https://bitbucket.org/pypy/pypy/downloads/pypy2-v5.6.0-src.tar.bz2#7411448045f77eb9e087afdce66fe7eafda1876c9e17aad88cf891f762b608b0" "pypy_builder" verify_py27 ensurepip


### PR DESCRIPTION
Tested on Ubuntu 16.04 64-bit up to the point where it starts translating.