### PR TITLE
Add Ironpython 2.7.7 rc2

### DIFF
--- a/plugins/python-build/share/python-build/ironpython-2.7.7-rc2
+++ b/plugins/python-build/share/python-build/ironpython-2.7.7-rc2
@@ -1,2 +1,2 @@
-install_zip "IronPython-2.7.7rc2" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7-rc2/IronPython-2.7.7rc2-unix.tar.bz2#338b855d007a2f8f12498fe67039483e671c98f6ea8320add4cdedd53b118113" ironpython
+install_package "IronPython-2.7.7rc2" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7-rc2/IronPython-2.7.7rc2-unix.tar.bz2#338b855d007a2f8f12498fe67039483e671c98f6ea8320add4cdedd53b118113" ironpython
 # FIXME: have not confirmed to install setuptools into IronPython yet

--- a/plugins/python-build/share/python-build/ironpython-2.7.7-rc2
+++ b/plugins/python-build/share/python-build/ironpython-2.7.7-rc2
@@ -1,0 +1,2 @@
+install_zip "IronPython-2.7.7rc2" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7-rc2/IronPython-2.7.7rc2-unix.tar.bz2#338b855d007a2f8f12498fe67039483e671c98f6ea8320add4cdedd53b118113" ironpython
+# FIXME: have not confirmed to install setuptools into IronPython yet


### PR DESCRIPTION
Tested on Ubuntu 16.04 64-bit, Mono version 4.6.1. Please note that there's a lot of startup error messages like, e.g.:

```
Error processing line 1 of /home/samo/.local/lib/python2.7/site-packages/virtualenvwrapper-4.7.2-py2.7-nspkg.pth:

  Traceback (most recent call last):
    File "/home/samo/.pyenv/versions/ironpython-2.7.7-rc2/bin/Lib/site.py", line 152, in addpackage
      exec line
    File "<string>", line 1, in <module>
  AttributeError: 'module' object has no attribute '_getframe'

Remainder of file ignored
IronPython 2.7.7rc2 (2.7.7.0) on Mono 4.0.30319.42000 (64-bit)
Type "help", "copyright", "credits" or "license" for more information.
>>> 
```
This was already reported in Ironlanguages/main#1469, main issue Ironlanguages/main#1072, current blocker seems to be Ironlanguages/main#1480.