### PR TITLE
Add Ironpython 2.7.7

### DIFF
--- a/plugins/python-build/share/python-build/ironpython-2.7.7
+++ b/plugins/python-build/share/python-build/ironpython-2.7.7
@@ -1,0 +1,2 @@
+install_package "IronPython-2.7.7" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7/IronPython-2.7.7-win.zip#657c134ff6d6f0ed86557d9455dcdfeac11823944f7aa36d72a41cc5444c4a89" ironpython
+# FIXME: have not confirmed to install setuptools into IronPython yet

--- a/plugins/python-build/share/python-build/ironpython-2.7.7
+++ b/plugins/python-build/share/python-build/ironpython-2.7.7
@@ -1,2 +1,2 @@
-install_zip "IronPython-2.7.7" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7/IronPython-2.7.7-win.zip#657c134ff6d6f0ed86557d9455dcdfeac11823944f7aa36d72a41cc5444c4a89" ironpython
-# FIXME: have not confirmed to install setuptools into IronPython yet
+install_zip "IronPython-2.7.7" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7/IronPython-2.7.7-win.zip#657c134ff6d6f0ed86557d9455dcdfeac11823944f7aa36d72a41cc5444c4a89" ironpython ensurepip
+

--- a/plugins/python-build/share/python-build/ironpython-2.7.7
+++ b/plugins/python-build/share/python-build/ironpython-2.7.7
@@ -1,2 +1,2 @@
-install_package "IronPython-2.7.7" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7/IronPython-2.7.7-win.zip#657c134ff6d6f0ed86557d9455dcdfeac11823944f7aa36d72a41cc5444c4a89" ironpython
+install_zip "IronPython-2.7.7" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7/IronPython-2.7.7-win.zip#657c134ff6d6f0ed86557d9455dcdfeac11823944f7aa36d72a41cc5444c4a89" ironpython
 # FIXME: have not confirmed to install setuptools into IronPython yet

--- a/plugins/python-build/share/python-build/ironpython-2.7.7-rc2
+++ b/plugins/python-build/share/python-build/ironpython-2.7.7-rc2
@@ -1,2 +1,0 @@
-install_package "IronPython-2.7.7rc2" "https://github.com/IronLanguages/main/releases/download/ipy-2.7.7-rc2/IronPython-2.7.7rc2-unix.tar.bz2#338b855d007a2f8f12498fe67039483e671c98f6ea8320add4cdedd53b118113" ironpython
-# FIXME: have not confirmed to install setuptools into IronPython yet


### PR DESCRIPTION
https://github.com/IronLanguages/main/releases/tag/ipy-2.7.7

Tested on Ubuntu 16.04 64-bits. Please note that:

- The following issues are still open:

> https://github.com/IronLanguages/main/issues/1072
> https://github.com/IronLanguages/main/issues/1480

Workarounds: either run `python` with `-s` (don't add user site directory to sys.path), `-S` (don't imply 'import site' on initialization) or `-X:Frames` (enable basic sys._getframe support)

- With verify_py27 enabled, it shows the following warning :

`WARNING: The Python readline extension was not compiled. Missing the GNU readline lib?`