### PR TITLE
README: multiple versions in .python-version

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,8 @@ in this example), but also have Python 3.3.6, 3.2, and 2.5 available on your
 global system 3.3.6 3.2 2.5`. At this point, one should be able to find the full
 executable path to each of these using `pyenv which`, e.g. `pyenv which python2.5`
 (should display `$PYENV_ROOT/versions/2.5/bin/python2.5`), or `pyenv which
-python3.4` (should display path to system Python3).
+python3.4` (should display path to system Python3). You can also specify multiple
+versions in a `.python-version` file, separated by newlines or any whitespace.
 
 ### Locating the Python Installation
 


### PR DESCRIPTION
Document that multiple versions in `.python-version` work similarly to the command line.