### PR TITLE
simple init.zsh

### DIFF
--- a/_pyenv
+++ b/_pyenv
@@ -1,0 +1,33 @@
+#compdef pyenv
+
+_pyenv() {
+  _arguments -s '*::pyenv command:_pyenv_command'
+}
+
+(( ${+functions[_pyenv_command]} )) || _pyenv_command() {
+  (( ${+_pyenv_cmds} )) || _pyenv_cmds=(${(f)"$(_call_program commands pyenv commands 2>&1)"})
+
+  if (( CURRENT == 1 )); then
+    _describe -t commands 'pyenv command' _pyenv_cmds
+  else
+    cmd=$words[1]
+    curcontext="${curcontext%:*:*}:pyenv-${cmd}:"
+    _call_function ret _pyenv_args $cmd || _message "no more arguments"
+    return ret
+  fi
+}
+
+(( ${+functions[_pyenv_args]} )) || _pyenv_args() {
+  _pyenv_args=(${(f)"$(_call_program commands pyenv completions $1 2>&1)"})
+  compadd -a _pyenv_args
+}
+
+_pyenv "${@}"
+
+# Local Variables:
+# mode: Shell-Script
+# sh-indentation: 2
+# indent-tabs-mode: nil
+# sh-basic-offset: 2
+# End:
+# vim: ft=zsh sw=2 ts=2 et

--- a/init.zsh
+++ b/init.zsh
@@ -1,8 +1,23 @@
-dir=$(dirname $0)
+root=$(dirname $0)
 
-for plugin in ${dir}/plugins/*; do
+for plugin in ${root}/plugins/*; do
     [ -d "${plugin}/bin" ] && export PATH="${plugin}/bin:$PATH"
 done
-export PATH="${dir}/bin:$PATH"
+
+export PATH="${root}/bin:$PATH"
+export PYENV_SHELL=zsh
+# fpath=($root/completions $fpath)
+
+# lazy pyenv init/rehash
+pyenv() {
+    unset -f pyenv
+
+    # make sure the shims are initiated and usable
+    mkdir -p "${PYENV_ROOT}/"{shims,versions}
+    export PATH="${PYENV_ROOT}/shims:${PATH}"
+    command pyenv rehash 2>/dev/null
+
+    ${root}/bin/pyenv "$@"
+}
 
 true # Return success exit code otherwise antigen breaks

--- a/init.zsh
+++ b/init.zsh
@@ -1,0 +1,8 @@
+dir=$(dirname $0)
+
+for plugin in ${dir}/plugins/*; do
+    [ -d "${plugin}/bin" ] && export PATH="${plugin}/bin:$PATH"
+done
+export PATH="${dir}/bin:$PATH"
+
+true # Return success exit code otherwise antigen breaks


### PR DESCRIPTION
Simple init.zsh that can be used by zgen/antigen to add pyenv to the PATH. This removes from the step 2 of the installation the need to manually change the path, eg.:

`echo 'export PATH="$PYENV_ROOT/bin:$PATH"' >> ~/.bash_profile`