### PR TITLE
use $ORIGIN for rpath so the built python can be copied

### DIFF
--- a/plugins/python-build/README.md
+++ b/plugins/python-build/README.md
@@ -153,12 +153,12 @@ You can build CPython with `--enable-shared` to install a version with
 shared object.
 
 If `--enabled-shared` was found in `PYTHON_CONFIGURE_OPTS` or `CONFIGURE_OPTS`,
-`python-build` will automatically set `RPATH` to the pyenv's prefix directory.
+`python-build` will automatically set `RPATH` to the pyenv's `bin/../lib` directory.
 This means you don't have to set `LD_LIBRARY_PATH` or `DYLD_LIBRARY_PATH` for
 the version(s) installed with `--enable-shared`.
 
 ```sh
-$ env PYTHON_CONFIGURE_OPTS="--enable-shared` pyenv install 2.7.9
+$ env PYTHON_CONFIGURE_OPTS="--enable-shared" pyenv install 2.7.9
 ```
 
 ### Checksum verification

--- a/plugins/python-build/bin/python-build
+++ b/plugins/python-build/bin/python-build
@@ -1911,7 +1911,7 @@ package_option python configure --libdir="${PREFIX_PATH}/lib"
 if [[ "$CONFIGURE_OPTS" == *"--enable-shared"* ]] || [[ "$PYTHON_CONFIGURE_OPTS" == *"--enable-shared"* ]]; then
   # The ld on Darwin embeds the full paths to each dylib by default
   if [[ "$LDFLAGS" != *"-rpath="* ]] && ! is_mac; then
-    export LDFLAGS="-Wl,-rpath=${PREFIX_PATH}/lib ${LDFLAGS}"
+    export LDFLAGS="-Wl,-rpath='\$\$ORIGIN/../lib' ${LDFLAGS}"
   fi
 fi
 


### PR DESCRIPTION
refer: https://medium.com/square-corner-blog/building-portable-binaries-50ca4f3d75cd#.8u7hwyz1v

built result: 

```
[root@maddog ~]# ldd python3/bin/python|grep libpython
        libpython3.5m.so.1.0 => /root/python3/bin/../lib/libpython3.5m.so.1.0 (0x00007fc9a1
42e000)
[root@maddog ~]# mv python3 python3.5.0
[root@maddog ~]# ldd python3.5.0/bin/python|grep libpython
        libpython3.5m.so.1.0 => /root/python3.5.0/bin/../lib/libpython3.5m.so.1.0 (0x00007f
79d800c000)

```