### PR TITLE
Fix fish subcommand completion

### DIFF
--- a/completions/pyenv.fish
+++ b/completions/pyenv.fish
@@ -18,5 +18,6 @@ end
 
 complete -f -c pyenv -n '__fish_pyenv_needs_command' -a '(pyenv commands)'
 for cmd in (pyenv commands)
-  complete -f -c pyenv -n "__fish_pyenv_using_command $cmd" -a "(pyenv completions $cmd)"
+  complete -f -c pyenv -n "__fish_pyenv_using_command $cmd" -a \
+    "(pyenv completions (commandline -opc)[2..-1])"
 end


### PR DESCRIPTION
This allows subcommand style plugins to properly autocomplete.
Existing commands are not affected. 

Example, say you have support for `pyenv foo bar --flag`, then
this allows the last `--flag` argument to be properly completed.