### PR TITLE
CPython now uses git

### DIFF
--- a/plugins/python-build/share/python-build/3.7-dev
+++ b/plugins/python-build/share/python-build/3.7-dev
@@ -1,4 +1,4 @@
 #require_gcc
 install_package "openssl-1.0.2g" "https://www.openssl.org/source/openssl-1.0.2g.tar.gz#b784b1b3907ce39abf4098702dade6365522a253ad1552e267a9a0e89594aa33" mac_openssl --if has_broken_mac_openssl
 install_package "readline-6.3" "https://ftpmirror.gnu.org/readline/readline-6.3.tar.gz#56ba6071b9462f980c5a72ab0023893b65ba6debb4eeb475d7a563dc65cafd43" standard --if has_broken_mac_readline
-install_hg "Python-3.7-dev" "https://hg.python.org/cpython" "default" standard verify_py37 ensurepip
+install_git "Python-3.7-dev" "https://github.com/python/cpython" master standard verify_py37 ensurepip


### PR DESCRIPTION
CPython has migrated to GitHub. [1][2] The old mercurial repository [3] is no longer updated.

[1] https://github.com/python/cpython/
[2] https://mail.python.org/pipermail/python-dev/2017-February/147381.html
[3] https://hg.python.org/cpython/